### PR TITLE
add address property to Document model

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -6,6 +6,7 @@ var pkg = require('./package'),
 
 function Document( type, id ){
   this.name = {};
+  this.address = {};
   this.center_point = {};
 
   // create a non-enumerable property for metadata
@@ -72,6 +73,14 @@ Document.prototype.getName = model.getChild( 'name' );
 Document.prototype.hasName = model.hasChild( 'name' );
 Document.prototype.delName = model.delChild( 'name' );
 
+// address
+Document.prototype.setAddress = model.setChild( 'address' )
+                                  .validate( valid.type('string') )
+                                  .validate( valid.truthy() );
+
+Document.prototype.getAddress = model.getChild( 'address' );
+Document.prototype.hasAddress = model.hasChild( 'address' );
+Document.prototype.delAddress = model.delChild( 'address' );
 
 // population
 Document.prototype.setPopulation = model.set( 'population', null, null, true)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ var poi = new Document( 'geoname', 1003 )
   .setName( 'alt', 'Haggerston City Farm' )
   .setAdmin( 'admin0', 'Great Britain' )
   .setAdmin( 'neighborhood', 'Shoreditch' )
+  .setAddress( 'number', '10' )
+  .setAddress( 'street', 'pelias place' )
   .setCentroid({ lon: 0.5, lat: 50.1 });
 
 console.log( poi );

--- a/test/document/address.js
+++ b/test/document/address.js
@@ -1,0 +1,61 @@
+
+var Document = require('../../Document');
+
+module.exports.tests = {};
+
+module.exports.tests.getAddress = function(test) {
+  test('getAddress', function(t) {
+    var doc = new Document('mytype','myid');
+    t.equal(doc.getAddress('foo'), undefined, 'getter works');
+    doc.address = { 'foo': 'bar' };
+    t.equal(doc.getAddress('foo'), 'bar', 'getter works');
+    t.end();
+  });
+};
+
+module.exports.tests.setAddress = function(test) {
+  test('setAddress', function(t) {
+    var doc = new Document('mytype','myid');
+    t.equal(doc.setAddress('foo','bar'), doc, 'chainable');
+    t.equal(doc.address.foo, 'bar', 'setter works');
+    t.end();
+  });
+  test('setAddress - validate', function(t) {
+    var doc = new Document('mytype','myid');
+    t.throws( doc.setAddress.bind(doc,1), null, 'invalid type' );
+    t.throws( doc.setAddress.bind(doc,''), null, 'invalid length' );
+    t.end();
+  });
+};
+
+module.exports.tests.hasAddress = function(test) {
+  test('hasAddress', function(t) {
+    var doc = new Document('mytype','myid');
+    t.equal(doc.hasAddress('foo'), false, 'hasser works');
+    doc.address.foo = 'bar';
+    t.equal(doc.hasAddress('foo'), true, 'hasser works');
+    t.end();
+  });
+};
+
+module.exports.tests.delAddress = function(test) {
+  test('delAddress', function(t) {
+    var doc = new Document('mytype','myid');
+    t.equal(doc.delAddress('foo'), false, 'deller works');
+    doc.address.foo = 'bar';
+    t.equal(doc.delAddress('foo'), true, 'deller works');
+    t.equal(doc.address.foo, undefined, 'deller works');
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('address: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/run.js
+++ b/test/run.js
@@ -14,6 +14,7 @@ var tests = [
   require('./document/popularity.js'),
   require('./document/population.js'),
   require('./document/name.js'),
+  require('./document/address.js'),
   require('./document/polygon.js'),
   require('./document/type.js')
 ];


### PR DESCRIPTION
the `address` property is already defined in `pelias/schema` [1] this PR simply exposes getter/setter methods to provide an interface to modify the address data.

[1] https://github.com/pelias/schema/blob/master/mappings/poi.js#L7