### PR TITLE
remove explicit truthy check

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -83,14 +83,14 @@ Document.prototype.hasAddress = model.hasChild( 'address' );
 Document.prototype.delAddress = model.delChild( 'address' );
 
 // population
-Document.prototype.setPopulation = model.set( 'population', null, null, true)
+Document.prototype.setPopulation = model.set( 'population', null, null )
                                         .validate( valid.type('number') )
                                         .validate( valid.positive() );
 
 Document.prototype.getPopulation = model.get( 'population' );
 
 // popularity
-Document.prototype.setPopularity = model.set( 'popularity', null, null, true)
+Document.prototype.setPopularity = model.set( 'popularity', null, null )
                                         .transform( transform.roundify() )
                                         .validate( valid.type('number') )
                                         .validate( valid.positive() );
@@ -99,7 +99,7 @@ Document.prototype.getPopularity = model.get( 'popularity' );
 
 // admin
 Document.prototype.setAdmin = function( prop, val ){
-  
+
   validAdminField( prop );
 
   return model.set( prop )

--- a/test/document/id.js
+++ b/test/document/id.js
@@ -20,10 +20,18 @@ module.exports.tests.setId = function(test) {
     t.equal(doc._meta.id, 'foo', 'id set');
     t.end();
   });
-  test('setId - validate', function(t) {
+  test('setId - validate id type', function(t) {
     var doc = new Document('mytype','myid');
-    t.throws( doc.setId.bind(doc,undefined), null, 'invalid type' );
-    t.throws( doc.setId.bind(doc,''), null, 'invalid length' );
+    t.throws( function(){
+      doc.setId( undefined );
+    });
+    t.end();
+  });
+  test('setId - validate id length', function(t) {
+    var doc = new Document('mytype','myid');
+    t.throws( function(){
+      doc.setId( '' );
+    });
     t.end();
   });
   test('setId - transform', function(t) {

--- a/test/document/latlon.js
+++ b/test/document/latlon.js
@@ -39,6 +39,16 @@ module.exports.tests.setLat = function(test) {
     t.equal(doc.center_point.lat, 1.476877, 'fixed precision');
     t.end();
   });
+  test('setLat - extremes', function(t) {
+    var doc = new Document('mytype','myid');
+    doc.setLat(-90);
+    t.equal(doc.center_point.lat, -90, 'accepts min');
+    doc.setLat(0);
+    t.equal(doc.center_point.lat, 0, 'accepts zero');
+    doc.setLat(90);
+    t.equal(doc.center_point.lat, 90, 'accepts max');
+    t.end();
+  });
 };
 
 module.exports.tests.getLon = function(test) {
@@ -75,6 +85,16 @@ module.exports.tests.setLon = function(test) {
     t.equal(doc.center_point.lon, 1.4, 'accepts strings');
     doc.setLon('1.476876786');
     t.equal(doc.center_point.lon, 1.476877, 'fixed precision');
+    t.end();
+  });
+  test('setLon - extremes', function(t) {
+    var doc = new Document('mytype','myid');
+    doc.setLon(-180);
+    t.equal(doc.center_point.lon, -180, 'accepts min');
+    doc.setLon(0);
+    t.equal(doc.center_point.lon, 0, 'accepts zero');
+    doc.setLon(+180);
+    t.equal(doc.center_point.lon, 180, 'accepts max');
     t.end();
   });
 };

--- a/test/document/popularity.js
+++ b/test/document/popularity.js
@@ -40,6 +40,12 @@ module.exports.tests.setPopularity = function(test) {
     t.equal(doc.popularity, 0, 'transforms: returns 0 incase of empty string');
     t.end();
   });
+  test('setPopularity - accept zero value', function(t) {
+    var doc = new Document('mytype','myid');
+    doc.setPopularity(0);
+    t.equal(doc.popularity, 0, 'allow zero popularity');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {

--- a/test/document/population.js
+++ b/test/document/population.js
@@ -28,6 +28,12 @@ module.exports.tests.setPopulation = function(test) {
     t.throws( doc.setPopulation.bind(doc,NaN), null, 'invalid: float value' );
     t.end();
   });
+  test('setPopulation - accept zero value', function(t) {
+    var doc = new Document('mytype','myid');
+    doc.setPopulation(0);
+    t.equal(doc.population, 0, 'allow zero population');
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {

--- a/util/model.js
+++ b/util/model.js
@@ -6,13 +6,12 @@ module.exports.get = function( prop ){
   };
 };
 
-module.exports.set = function( prop, validators, transformers, zeroIsValid ){
+module.exports.set = function( prop, validators, transformers ){
   if( !prop ){ throw new Error( 'invalid property' ); }
   if( !validators ){ validators = []; }
   if( !transformers ){ transformers = []; }
   var setter = function( val ){
-    if( !val && !zeroIsValid){ throw new Error( 'invalid value' ); }
-    
+
     val = transform( val, transformers );
     validate( val, validators );
     this[prop] = val;
@@ -53,7 +52,6 @@ module.exports.setChild = function( child, validators, transformers ){
   if( !transformers ){ transformers = []; }
   var setter = function( prop, val ){
     if( !prop ){ throw new Error( 'invalid property' ); }
-    if( !val ){ throw new Error( 'invalid value' ); }
 
     val = transform( val, transformers );
     validate( val, validators );

--- a/util/transform.js
+++ b/util/transform.js
@@ -13,6 +13,10 @@ module.exports.lowercase = function(){
 
 module.exports.stringify = function(){
   return function( val ){
+    // because javascript: (''+undefined) === 'undefined'
+    if( 'undefined' === typeof val ){
+      return '';
+    }
     return '' + val;
   };
 };


### PR DESCRIPTION
The explicit truthy checks [1] and [2] made it difficult to deal with zero values, @hkrishna did a PR to try to revolve this issue which added a `zeroIsValid` property, this was not applied to the `setChild` method [2] and so in order to resolve https://github.com/pelias/openstreetmap/issues/42 (allowing zero values as valid lat/lon co-ords) I needed to revisit this issue.

In order to simplify the code I removed the `zeroIsValid` flag and fixed the stringify coercion; because javascript [3]


[1] https://github.com/pelias/model/blob/8a311de4678b6946400bbb7ec24b3306326f1a1a/util/model.js#L14
[2] https://github.com/pelias/model/blob/8a311de4678b6946400bbb7ec24b3306326f1a1a/util/model.js#L56
[3] https://github.com/pelias/model/compare/explicit_truthy?expand=1#diff-3fe73be3add3db1626cc2c371bed5910R16