### PR TITLE
Add document mapper stream

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -39,6 +39,18 @@ Document.prototype.toJSON = function(){
   return this;
 };
 
+/*
+ * Returns an object in exactly the format that Elasticsearch wants for inserts
+ */
+Document.prototype.toESDocument = function() {
+  return {
+    _index: 'pelias', // TODO: make this configuration-driven
+    _type: this.getType(),
+    _id: this.getId(),
+    data: this
+  };
+};
+
 // id
 Document.prototype.setId = function( id ){
   return model.setChild( '_meta' )

--- a/DocumentMapperStream.js
+++ b/DocumentMapperStream.js
@@ -1,0 +1,9 @@
+var through = require('through2');
+
+function createDocumentMapperStream() {
+  return through.obj( function( model, enc, next ){
+    next(null, model.toESDocument());
+  });
+}
+
+module.exports = createDocumentMapperStream;

--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-
 module.exports.Document = require('./Document');
+module.exports.createDocumentMapperStream = require('./DocumentMapperStream');

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
     "npm": ">=1.4.3"
   },
   "dependencies": {
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "through2": "^2.0.0"
   },
   "devDependencies": {
-    "tape": "^2.13.4",
+    "event-stream": "^3.3.2",
+    "precommit-hook": "1.0.7",
     "tap-spec": "^0.2.0",
-    "precommit-hook": "1.0.7"
+    "tape": "^2.13.4"
   }
 }

--- a/test/DocumentMapperStream.js
+++ b/test/DocumentMapperStream.js
@@ -1,0 +1,37 @@
+var event_stream = require('event-stream');
+
+var createDocumentMapperStream = require('../DocumentMapperStream');
+var Document = require('../Document');
+
+function test_stream(input, testedStream, callback) {
+  var input_stream = event_stream.readArray(input);
+  var destination_stream = event_stream.writeArray(callback);
+
+  input_stream.pipe(testedStream).pipe(destination_stream);
+}
+
+module.exports.tests = {};
+
+module.exports.tests.DocumentMapperStream = function(test) {
+  test('createDocumentMapperStream', function(t) {
+    var stream = createDocumentMapperStream();
+    var document = new Document('source', 'layer', 'id');
+
+    test_stream([document], stream, function(err, results) {
+      t.equal(results.length, 1, 'stream returns exactly one result');
+      t.deepEqual(results[0], document.toESDocument(),
+                  'stream transforms Document into object ready to be inserted into Elasticsearch');
+      t.end();
+    });
+  });
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('DocumentMapperStream: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -1,0 +1,27 @@
+var Document = require('../../Document');
+
+module.exports.tests = {};
+
+module.exports.tests.toESDocument = function(test) {
+  test('toESDocument', function(t) {
+    var doc = new Document('mysource','mylayer','myid');
+    var expected = {
+      _index: 'pelias',
+      _type: 'mylayer',
+      _id: 'myid',
+      data: doc
+    };
+    t.deepEqual(doc.toESDocument(), expected, 'creates correct elasticsearch document');
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+  function test(name, testFunction) {
+    return tape('Document: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/run.js
+++ b/test/run.js
@@ -23,6 +23,7 @@ var tests = [
   require('./document/source.js'),
   require('./document/layer.js'),
   require('./document/source_id.js'),
+  require('./document/toESDocument.js'),
   require('./util/transform.js'),
   require('./util/model.js'),
   require('./serialize/test.js'),

--- a/test/run.js
+++ b/test/run.js
@@ -24,6 +24,7 @@ var tests = [
   require('./document/layer.js'),
   require('./document/source_id.js'),
   require('./document/toESDocument.js'),
+  require('./DocumentMapperStream.js'),
   require('./util/transform.js'),
   require('./util/model.js'),
   require('./serialize/test.js'),


### PR DESCRIPTION
This is an addition to the `wof_refactor` branch that adds a `Document.toESDocument` method, and a stream that, given Documents, transforms them by calling `toESDocument`. This consolidates the code to do the same thing in our importers [here](https://github.com/pelias/openstreetmap/blob/master/stream/dbmapper.js#L9), [here](https://github.com/pelias/openaddresses/blob/master/lib/import_pipelines.js#L104), [here](https://github.com/pelias/quattroshapes/blob/master/example/runme.js#L151), [here](https://github.com/pelias/geonames/blob/master/task/import.js#L126) and [here](https://github.com/pelias/whosonfirst/blob/master/src/elasticsearchPipeline.js#L13)

Required for pelias/pelias#234