### PR TITLE
Strip empty arrays and maps from the es document before sending it downstream

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -156,6 +156,30 @@ Document.prototype.addParent = function( field, name, id, abbr ){
   add( field + '_id', id );
 
   // optional field, eg: 'country_a', defaults to `null` for downstream ES
+  /**
+    note: the rationale for setting this field as 'null' instead of 'undefined'
+    is so that each of the fields 'line-up'.
+
+    == if you add a parent property with no abbreviation, as such:
+
+    setParent( 'region', 'foobar', '1' )
+
+    doc:
+      parent.region       = [ 'foobar' ]
+      parent.region_id    = [ '1' ]
+      parent.region_a     = [ null ]
+
+    == and then you add another parent property such as:
+
+    setParent( 'region', 'bingobango', '2', 'bingo' )
+
+    doc:
+      parent.region       = [ 'foobar', 'bingobango' ]
+      parent.region_id    = [ '1',      '2' ]
+      parent.region_a     = [ null,     'bingo' ]
+
+    == you can now be sure that the abbreviation 'bingo' belongs to '2' and not '1'.
+  **/
   if (_.isUndefined(abbr)) {
     var addNull = model.pushChild( 'parent' ).bind(this);
     addNull( field + '_a', null );

--- a/Document.js
+++ b/Document.js
@@ -48,7 +48,7 @@ Document.prototype.toESDocument = function() {
     _type: this.getType(),
     _id: this.getId(),
     data: JSON.parse( JSON.stringify( this, function( k, v ){
-      if( _.isEmpty(v) ){
+      if((_.isArray(v) || _.isPlainObject(v)) && _.isEmpty(v) ){
         return undefined;
       }
       return v;

--- a/Document.js
+++ b/Document.js
@@ -47,7 +47,12 @@ Document.prototype.toESDocument = function() {
     _index: 'pelias', // TODO: make this configuration-driven
     _type: this.getType(),
     _id: this.getId(),
-    data: this
+    data: JSON.parse( JSON.stringify( this, function( k, v ){
+      if( _.isEmpty(v) ){
+        return undefined;
+      }
+      return v;
+    }))
   };
 };
 

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -4,14 +4,29 @@ module.exports.tests = {};
 
 module.exports.tests.toESDocument = function(test) {
   test('toESDocument', function(t) {
+
     var doc = new Document('mysource','mylayer','myid');
+    var esDoc = doc.toESDocument();
+
     var expected = {
       _index: 'pelias',
       _type: 'mylayer',
       _id: 'myid',
-      data: doc
+      data: {
+        layer: 'mylayer',
+        parent: {},
+        source: 'mysource',
+        source_id: 'myid'
+      }
     };
-    t.deepEqual(doc.toESDocument(), expected, 'creates correct elasticsearch document');
+
+    t.deepEqual(esDoc, expected, 'creates correct elasticsearch document');
+
+    // test that empty arrays/object are stripped from the doc before sending it
+    // downstream to elasticsearch.
+    t.false(esDoc.data.hasOwnProperty('address_parts'), 'does not include empty top-level maps');
+    t.false(esDoc.data.hasOwnProperty('category'), 'does not include empty top-level arrays');
+    t.false(esDoc.data.parent.hasOwnProperty('country'), 'does not include empty parent arrays');
     t.end();
   });
 };


### PR DESCRIPTION
strip empty arrays and maps from the es document before sending it downstream

prior to this PR when we send quite large documents to ES, a big chunk of the request body can be empty arrays for the `parent.*` fields or an empty `{}` for `address_parts`.

the downside of having these empty fields is 1. network overhead, 2. they actually get stored in the index despite contain no true 'values' and get returned to API from the cluster.

this has actually been bugging me for some time but I didn't know how best to deal with it, in the end I used `JSON.parse( JSON.stringify( _, replacer ) )` to do the job, its a little more CPU but seemed better than the other approaches I considered (key checks on each insert).

I'm hoping we get a little performance bump out of ES due to the reduced size of documents (by up to 80%) being sent around the cluster and when responding to requests from the REST API.

Also! this will make the `sense` output much easier to read :)

the only worry here is that somewhere in the API codebase we are not checking the existence of these fields (eg. we can now return a doc with no `doc.category = []` array when that array is empty); so we might need to add some key checks there.

an example of the fields produced before and after the PR (for a bare-minimal document):

```javascript
{
  _id: "myid",
  _index: "pelias",
  _type: "mylayer",
  data: {
    address_parts: {},
    category: [],
    center_point: {},
    layer: "mylayer",
    name: {},
    parent: {
      borough: [],
      borough_a: [],
      borough_id: [],
      country: [],
      country_a: [],
      country_id: [],
      county: [],
      county_a: [],
      county_id: [],
      localadmin: [],
      localadmin_a: [],
      localadmin_id: [],
      locality: [],
      locality_a: [],
      locality_id: [],
      macrocounty: [],
      macrocounty_a: [],
      macrocounty_id: [],
      macroregion: [],
      macroregion_a: [],
      macroregion_id: [],
      neighbourhood: [],
      neighbourhood_a: [],
      neighbourhood_id: [],
      region: [],
      region_a: [],
      region_id: []
    },
    phrase: {},
    source: "mysource",
    source_id: "myid"
  }
}
```

```javascript
{
  _id: "myid",
  _index: "pelias",
  _type: "mylayer",
  data: {
    layer: "mylayer",
    parent: {},
    source: "mysource",
    source_id: "myid"
  }
}
```

note: the `parent: {}` remains due to the nature of how the replacer function works; when that key is checked it still contains a bunch of arrays, so it's not considered empty. it looks like getting rid of that property would require some nasty code and more CPU so I'm happy to live with it as-is.