### PR TITLE
added `clearChild` to model and `clearParent` to Document

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -192,6 +192,17 @@ Document.prototype.addParent = function( field, name, id, abbr ){
   return this;
 };
 
+// clear all all added values
+Document.prototype.clearParent = function(field) {
+  var clear = model.clearChild( 'parent' ).bind(this);
+
+  clear( field );
+  clear( field + '_id' );
+  clear( field + '_a' );
+
+  return this;
+};
+
 // address
 Document.prototype.setAddress = function ( prop, val ){
   return model.setChild( 'address_parts' )

--- a/test/Document.js
+++ b/test/Document.js
@@ -53,6 +53,27 @@ module.exports.tests.constructor = function(test) {
   });
 };
 
+module.exports.tests.clearParent = function(test) {
+  test('clearParent should remove all effects of addParent calls', function(t) {
+    var doc = new Document('mysource','mylayer','myid');
+    doc.addParent('locality', 'name 1', 'id 1', 'abbr 1');
+    doc.addParent('locality', 'name 2', 'id 2', 'abbr 2');
+
+    t.deepEqual(doc.parent.locality, ['name 1', 'name 2'], 'should be empty');
+    t.deepEqual(doc.parent.locality_id, ['id 1', 'id 2'], 'should be empty');
+    t.deepEqual(doc.parent.locality_a, ['abbr 1', 'abbr 2'], 'should be empty');
+
+    doc.clearParent('locality');
+
+    t.deepEqual(doc.parent.locality, [], 'should be empty');
+    t.deepEqual(doc.parent.locality_id, [], 'should be empty');
+    t.deepEqual(doc.parent.locality_a, [], 'should be empty');
+
+    t.end();
+
+  });
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/test/util/model.js
+++ b/test/util/model.js
@@ -297,6 +297,28 @@ module.exports.tests.pushChild = function(test) {
   });
 };
 
+module.exports.tests.clearChild = function(test) {
+  test('clearChild()', function(t) {
+    // invalid prop
+    t.throws( model.clearChild.bind(null, null), /invalid child/ );
+
+    // clearer
+    var clear = model.clearChild('myKey');
+    t.equal( typeof clear, 'function', 'returns function' );
+    t.equal( clear.length, 1, 'returns function' );
+
+    // inheritance
+    var obj = { foo: { baz: [1, 2] } };
+    obj.clearChildFoo = model.clearChild('foo');
+    var chain = obj.clearChildFoo('baz');
+    t.deepEqual( obj.foo.baz, [], 'empty array' );
+    t.equal( chain, obj, 'methods chainable' );
+
+    t.end();
+
+  });
+};
+
 module.exports.tests.spliceChild = function(test) {
   test('spliceChild()', function(t) {
 

--- a/util/model.js
+++ b/util/model.js
@@ -265,6 +265,34 @@ module.exports.pushChild = function( child, validators, transformers ){
 };
 
 /**
+  Clear a value from the Array stored at a root property of the model.
+
+  // example:
+  model.items = [];
+  var push = model.push('items')
+  push('item1') // returns: model
+  push('item2') // returns: model
+  model.clear('items')
+  // effect: model.items = []
+
+**/
+module.exports.clearChild = function(child) {
+  if( !child ){ throw new PeliasModelError( 'invalid child' ); }
+  var clearer = function(prop) {
+    if( !prop ){ throw new PeliasModelError( 'invalid property' ); }
+    if( !this.hasOwnProperty(child) ){ throw new PeliasModelError( 'invalid child' ); }
+    if( 'object' !== typeof this[child] ){ throw new PeliasModelError( 'invalid child' ); }
+    if( null === this[child] ){ throw new PeliasModelError( 'invalid child' ); }
+    if( !this[child].hasOwnProperty(prop) ){ throw new PeliasModelError( 'invalid child' ); }
+    if( !Array.isArray(this[child][prop]) ){ throw new PeliasModelError( 'invalid child' ); }
+
+    this[child][prop] = [];
+    return this;
+  };
+  return clearer;
+};
+
+/**
   Remove a value from the Array stored at a root property of the model.
 
   // example:


### PR DESCRIPTION
For pelias/geonames#92, the geonames importer should ignore the `locality` and `localadmin` values coming back from wof-admin-lookup and override with the geonames `name` value.  This PR exposes a method that allows a field to be completely removed from a `Document` instance. 