### PR TITLE
Configurable index name

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -1,8 +1,8 @@
-var pkg = require('./package'),
-    model = require('./util/model'),
-    valid = require('./util/valid'),
-    transform = require('./util/transform'),
-    _ = require('lodash');
+var pkg = require('./package');
+var model = require('./util/model');
+var valid = require('./util/valid');
+var transform = require('./util/transform');
+var _ = require('lodash');
 
 function Document( source, layer, source_id ){
   this.name = {};

--- a/Document.js
+++ b/Document.js
@@ -1,4 +1,3 @@
-
 var pkg = require('./package'),
     model = require('./util/model'),
     valid = require('./util/valid'),

--- a/Document.js
+++ b/Document.js
@@ -1,3 +1,5 @@
+var config = require('pelias-config').generate();
+
 var pkg = require('./package');
 var model = require('./util/model');
 var valid = require('./util/valid');
@@ -43,7 +45,7 @@ Document.prototype.toJSON = function(){
  */
 Document.prototype.toESDocument = function() {
   return {
-    _index: 'pelias', // TODO: make this configuration-driven
+    _index: config.schema.indexName,
     _type: this.getType(),
     _id: this.getId(),
     data: JSON.parse( JSON.stringify( this, function( k, v ){

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "event-stream": "^3.3.2",
     "precommit-hook": "^3.0.0",
+    "proxyquire": "^1.7.10",
     "tap-spec": "^4.1.1",
     "tape": "^4.4.0",
     "semantic-release": "^4.3.5"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "lodash": "^4.6.1",
+    "pelias-config": "2.1.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -1,9 +1,23 @@
-var Document = require('../../Document');
+var proxyquire = require('proxyquire');
+
+var fakeGeneratedConfig = {
+  schema: {
+    indexName: 'pelias'
+  }
+};
+
+var fakeConfig = {
+  generate: function fakeGenerate() {
+    return fakeGeneratedConfig;
+  }
+};
+
 
 module.exports.tests = {};
 
 module.exports.tests.toESDocument = function(test) {
   test('toESDocument', function(t) {
+    var Document = proxyquire('../../Document', { 'pelias-config': fakeConfig });
 
     var doc = new Document('mysource','mylayer','myid');
     var esDoc = doc.toESDocument();
@@ -27,6 +41,25 @@ module.exports.tests.toESDocument = function(test) {
     t.false(esDoc.data.hasOwnProperty('address_parts'), 'does not include empty top-level maps');
     t.false(esDoc.data.hasOwnProperty('category'), 'does not include empty top-level arrays');
     t.false(esDoc.data.parent.hasOwnProperty('country'), 'does not include empty parent arrays');
+    t.end();
+  });
+};
+
+module.exports.tests.toESDocumentWithCustomConfig = function(test) {
+  test('toESDocument with custom config', function(t) {
+    fakeGeneratedConfig = {
+      schema: {
+        indexName: 'alternateindexname'
+      }
+    };
+
+    var Document = proxyquire('../../Document', { 'pelias-config': fakeConfig });
+
+    var doc = new Document('mysource','mylayer','myid');
+    var esDoc = doc.toESDocument();
+
+    t.deepEqual(esDoc._index, 'alternateindexname', 'document has correct index');
+
     t.end();
   });
 };


### PR DESCRIPTION
As part of https://github.com/pelias/api/issues/334, we want to be able to configure which Elasticsearch index documents are sent to as they are created. The model code was hardcoded to use `pelias` as the index name. 

Note: this code uses proxyquire to fake using the pelias-config in the tests, and I think it turned out pretty nicely, so check it out.

Requires https://github.com/pelias/config/pull/30 to be merged and pushed as a new version first (update: that PR has been merged and version 2.1.0 includes those changes)