### PR TITLE
Added convenience functions

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -137,6 +137,8 @@ Document.prototype.setAlpha3 = model.set( 'alpha3' )
 
 Document.prototype.getAlpha3 = model.get( 'alpha3' );
 
+Document.prototype.clearAlpha3 = model.clear( 'alpha3' );
+
 // globally unique id
 Document.prototype.getGid = function(){
   return [ this.getSource(), this.getLayer(), this.getId() ].join(':');

--- a/Document.js
+++ b/Document.js
@@ -226,6 +226,14 @@ Document.prototype.clearParent = function(field) {
   return this;
 };
 
+// convenience method for clearing all parents
+Document.prototype.clearAllParents = function() {
+  parentFields.forEach((parentField) => {
+    this.clearParent.call( this, parentField );
+  });
+  return this;
+};
+
 // address
 Document.prototype.setAddress = function ( prop, val ){
   return model.setChild( 'address_parts' )

--- a/test/Document.js
+++ b/test/Document.js
@@ -73,6 +73,30 @@ module.exports.tests.clearParent = function(test) {
   });
 };
 
+module.exports.tests.clearAllParents = (test) => {
+  test('clearParents should remove all effects of all addParent calls', (t) => {
+    const doc = new Document('mysource','mylayer','myid');
+    doc.getParentFields().forEach((type) => {
+      doc.addParent(type, 'name 1', 'id 1', 'abbr 1');
+      doc.addParent(type, 'name 2', 'id 2', 'abbr 2');
+    });
+
+    doc.getParentFields().forEach((type) => {
+      t.equals(doc.parent[type].length, 2, `there should be 2 of type ${type}`);
+    });
+
+    t.equals(doc.clearAllParents(), doc, 'is chainable');
+
+    doc.getParentFields().forEach((type) => {
+      t.equals(doc.parent[type].length, 0, `there should be 0 of type ${type}`);
+    });
+
+    t.end();
+
+  });
+
+};
+
 module.exports.tests.parent_types = (test) => {
   test('supported WOF placetypes should return true', (t) => {
     const doc = new Document('mysource', 'mylayer', 'myid');

--- a/test/document/alpha3.js
+++ b/test/document/alpha3.js
@@ -36,6 +36,22 @@ module.exports.tests.setAlpha3 = function(test) {
   });
 };
 
+module.exports.tests.clearAlpha3 = (test) => {
+  test('clearAlpha3', (t) => {
+    var doc = new Document('mysource','mylayer','myid');
+    doc.setAlpha3('FOO');
+
+    t.equal(doc.getAlpha3(), 'FOO', 'alpha3 set');
+
+    doc.clearAlpha3();
+
+    t.equal(doc.getAlpha3(), undefined, 'alpha3 cleared');
+    t.end();
+
+  });
+
+};
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/test/util/model.js
+++ b/test/util/model.js
@@ -81,6 +81,29 @@ module.exports.tests.set = function(test) {
   });
 };
 
+module.exports.tests.clear = (test) => {
+  test('clear()', (t) => {
+
+    // invalid prop
+    t.throws( model.clear.bind(null, null), /invalid property/ );
+
+    // clear-er
+    const clear = model.clear('myKey');
+    t.equal( typeof clear, 'function', 'returns function' );
+    t.equal( clear.length, 0, 'returns function' );
+
+    // inheritance
+    const obj = { key1: 'value1', key2: 'value2' };
+    obj.clearKey1 = model.clear('key1');
+    const chain = obj.clearKey1();
+    t.notOk(obj.hasOwnProperty('key1'), 'key1 should be gone');
+    t.deepEquals(obj.key2, 'value2', 'key2 should remain' );
+    t.equal( chain, obj, 'methods chainable' );
+
+    t.end();
+  });
+};
+
 module.exports.tests.getChild = function(test) {
   test('getChild()', function(t) {
 

--- a/util/model.js
+++ b/util/model.js
@@ -70,6 +70,18 @@ module.exports.set = function( prop, validators, transformers, postValidationTra
   return setter;
 };
 
+// clears the value of a property
+module.exports.clear = (prop) => {
+  if( !prop ) {
+    throw new PeliasModelError( 'invalid property' );
+  }
+  return function() {
+    delete this[prop];
+    // make chainable
+    return this;
+  };
+};
+
 /**
   Get the value of a property from a *second level* property of the model.
 


### PR DESCRIPTION
Since cloning a `Document` doesn't work, these are useful for handling WOF records with multiple hierarchies:

- `clearAlpha3()`
- `clearAllParents()`