### PR TITLE
feat(refactor): refactor toESDocument() to be more efficient

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -67,9 +67,15 @@ Document.prototype.toESDocument = function() {
   };
 
   // remove empty properties
-  if( _.isEmpty( doc.parent ) ){ delete doc.parent; }
-  if( _.isEmpty( doc.address_parts ) ){ delete doc.address_parts; }
-  if( _.isEmpty( this.category ) ){ delete doc.category; }
+  if( !Object.keys( doc.parent || {} ).length ){
+    delete doc.parent;
+  }
+  if( !Object.keys( doc.address_parts || {} ).length ){
+    delete doc.address_parts;
+  }
+  if( !( this.category || [] ).length ){
+    delete doc.category;
+  }
 
   return {
     _index: config.schema.indexName,

--- a/Document.js
+++ b/Document.js
@@ -67,11 +67,8 @@ Document.prototype.toESDocument = function() {
   };
 
   // remove empty properties
-  if( _.isEmpty( doc.name ) ){ delete doc.name; }
-  if( _.isEmpty( doc.phrase ) ){ delete doc.phrase; }
   if( _.isEmpty( doc.parent ) ){ delete doc.parent; }
   if( _.isEmpty( doc.address_parts ) ){ delete doc.address_parts; }
-  if( _.isEmpty( this.center_point ) ){ delete doc.center_point; }
   if( _.isEmpty( this.category ) ){ delete doc.category; }
 
   return {

--- a/Document.js
+++ b/Document.js
@@ -54,16 +54,31 @@ Document.prototype.toJSON = function(){
  * Returns an object in exactly the format that Elasticsearch wants for inserts
  */
 Document.prototype.toESDocument = function() {
+  var doc = {
+    name: this.name,
+    phrase: this.phrase,
+    parent: this.parent,
+    address_parts: this.address_parts,
+    center_point: this.center_point,
+    category: this.category,
+    source: this.source,
+    layer: this.layer,
+    source_id: this.source_id
+  };
+
+  // remove empty properties
+  if( _.isEmpty( doc.name ) ){ delete doc.name; }
+  if( _.isEmpty( doc.phrase ) ){ delete doc.phrase; }
+  if( _.isEmpty( doc.parent ) ){ delete doc.parent; }
+  if( _.isEmpty( doc.address_parts ) ){ delete doc.address_parts; }
+  if( _.isEmpty( this.center_point ) ){ delete doc.center_point; }
+  if( _.isEmpty( this.category ) ){ delete doc.category; }
+
   return {
     _index: config.schema.indexName,
     _type: this.getType(),
     _id: this.getId(),
-    data: JSON.parse( JSON.stringify( this, function( k, v ){
-      if((_.isArray(v) || _.isPlainObject(v)) && _.isEmpty(v) ){
-        return undefined;
-      }
-      return v;
-    }))
+    data: doc
   };
 };
 

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -27,7 +27,10 @@ module.exports.tests.toESDocument = function(test) {
       _type: 'mylayer',
       _id: 'myid',
       data: {
+        center_point: {},
         layer: 'mylayer',
+        name: {},
+        phrase: {},
         source: 'mysource',
         source_id: 'myid'
       }


### PR DESCRIPTION
refactor code for performance & readability

this PR removes the slow JSON serialize/deserialize code. that code converts each object to a string and then back in to an object in order to take advantage of a feature in `JSON.stringify` which removes empty properties.

it turns out this is potentially slow, so I refactored the code to do the same thing using a different method.

benchmarks:
```bash
#### calling constructor, all setter methods and toESDocument()

# before (after the previous PR was merged)
imported 10000 docs in 1124 ms
average speed: 0.1124 ms

# after
imported 10000 docs in 290 ms
average speed: 0.0290 ms
```

works out to be ~75% faster, multiplied out to 500 million records, this change could save 10+ hrs