### PR TITLE
expose missing things from toESDocument

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -63,7 +63,8 @@ Document.prototype.toESDocument = function() {
     category: this.category,
     source: this.source,
     layer: this.layer,
-    source_id: this.source_id
+    source_id: this.source_id,
+    bounding_box: this.bounding_box
   };
 
   // remove empty properties

--- a/Document.js
+++ b/Document.js
@@ -64,7 +64,10 @@ Document.prototype.toESDocument = function() {
     source: this.source,
     layer: this.layer,
     source_id: this.source_id,
-    bounding_box: this.bounding_box
+    bounding_box: this.bounding_box,
+    popularity: this.popularity,
+    population: this.population,
+    polygon: this.shape
   };
 
   // remove empty properties
@@ -82,6 +85,15 @@ Document.prototype.toESDocument = function() {
   }
   if( !Object.keys( doc.center_point || {} ).length ){
     delete doc.center_point;
+  }
+  if (!this.population) {
+    delete doc.population;
+  }
+  if (!this.popularity) {
+    delete doc.popularity;
+  }
+  if( !Object.keys( doc.polygon || {} ).length ){
+    delete doc.polygon;
   }
 
   return {

--- a/Document.js
+++ b/Document.js
@@ -77,6 +77,12 @@ Document.prototype.toESDocument = function() {
   if( !( this.category || [] ).length ){
     delete doc.category;
   }
+  if (!this.bounding_box) {
+    delete doc.bounding_box;
+  }
+  if( !Object.keys( doc.center_point || {} ).length ){
+    delete doc.center_point;
+  }
 
   return {
     _index: config.schema.indexName,

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -38,7 +38,6 @@ module.exports.tests.toESDocument = function(test) {
       _type: 'mylayer',
       _id: 'myid',
       data: {
-        center_point: {},
         layer: 'mylayer',
         name: {},
         phrase: {},
@@ -57,6 +56,31 @@ module.exports.tests.toESDocument = function(test) {
     t.false(esDoc.data.hasOwnProperty('parent'), 'does not include empty parent arrays');
     t.end();
   });
+
+  test('unset bounding_box should not output in toESDocument', (t) => {
+    var Document = proxyquire('../../Document', { 'pelias-config': fakeConfig });
+
+    var doc = new Document('mysource','mylayer','myid');
+
+    var esDoc = doc.toESDocument();
+
+    t.false(esDoc.data.hasOwnProperty('bounding_box'), 'should not include bounding_box');
+    t.end();
+
+  });
+
+  test('unset lat/lon should not output center in toESDocument', (t) => {
+    var Document = proxyquire('../../Document', { 'pelias-config': fakeConfig });
+
+    var doc = new Document('mysource','mylayer','myid');
+
+    var esDoc = doc.toESDocument();
+
+    t.false(esDoc.data.hasOwnProperty('center_point'), 'should not include center');
+    t.end();
+
+  });
+
 };
 
 module.exports.tests.toESDocumentWithCustomConfig = function(test) {

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -30,6 +30,9 @@ module.exports.tests.toESDocument = function(test) {
         lon: 31.313131
       }
     });
+    doc.setPopulation(123);
+    doc.setPopularity(456);
+    doc.setPolygon({ key: 'value' });
 
     var esDoc = doc.toESDocument();
 
@@ -43,7 +46,10 @@ module.exports.tests.toESDocument = function(test) {
         phrase: {},
         source: 'mysource',
         source_id: 'myid',
-        bounding_box: '{"min_lat":12.121212,"max_lat":13.131313,"min_lon":21.212121,"max_lon":31.313131}'
+        bounding_box: '{"min_lat":12.121212,"max_lat":13.131313,"min_lon":21.212121,"max_lon":31.313131}',
+        population: 123,
+        popularity: 456,
+        polygon: { key: 'value' }
       }
     };
 
@@ -57,7 +63,7 @@ module.exports.tests.toESDocument = function(test) {
     t.end();
   });
 
-  test('unset bounding_box should not output in toESDocument', (t) => {
+  test('unset properties should not output in toESDocument', (t) => {
     var Document = proxyquire('../../Document', { 'pelias-config': fakeConfig });
 
     var doc = new Document('mysource','mylayer','myid');
@@ -65,18 +71,10 @@ module.exports.tests.toESDocument = function(test) {
     var esDoc = doc.toESDocument();
 
     t.false(esDoc.data.hasOwnProperty('bounding_box'), 'should not include bounding_box');
-    t.end();
-
-  });
-
-  test('unset lat/lon should not output center in toESDocument', (t) => {
-    var Document = proxyquire('../../Document', { 'pelias-config': fakeConfig });
-
-    var doc = new Document('mysource','mylayer','myid');
-
-    var esDoc = doc.toESDocument();
-
     t.false(esDoc.data.hasOwnProperty('center_point'), 'should not include center');
+    t.false(esDoc.data.hasOwnProperty('population'), ' should not include population');
+    t.false(esDoc.data.hasOwnProperty('popularity'), ' should not include popularity');
+    t.false(esDoc.data.hasOwnProperty('polygon'), ' should not include polygon');
     t.end();
 
   });

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -77,10 +77,8 @@ module.exports.tests.toESDocument = function(test) {
     };
 
     t.deepEqual(esDoc, expected, 'creates correct elasticsearch document');
-
-    // test that empty arrays/object are stripped from the doc before sending it
-    // downstream to elasticsearch.
     t.end();
+    
   });
 
   test('unset properties should not output in toESDocument', (t) => {
@@ -88,6 +86,8 @@ module.exports.tests.toESDocument = function(test) {
 
     const esDoc = new Document('mysource','mylayer','myid').toESDocument();
 
+    // test that empty arrays/object are stripped from the doc before sending it
+    // downstream to elasticsearch.
     t.false(esDoc.data.hasOwnProperty('address_parts'), 'does not include empty top-level maps');
     t.false(esDoc.data.hasOwnProperty('category'), 'does not include empty top-level arrays');
     t.false(esDoc.data.hasOwnProperty('parent'), 'does not include empty parent arrays');

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -20,6 +20,7 @@ module.exports.tests.toESDocument = function(test) {
     var Document = proxyquire('../../Document', { 'pelias-config': fakeConfig });
 
     var doc = new Document('mysource','mylayer','myid');
+    doc.setName('myprop', 'myname');
     doc.setBoundingBox({
       upperLeft: {
         lat: 13.131313,
@@ -42,8 +43,12 @@ module.exports.tests.toESDocument = function(test) {
       _id: 'myid',
       data: {
         layer: 'mylayer',
-        name: {},
-        phrase: {},
+        name: {
+          myprop: 'myname'
+        },
+        phrase: {
+          myprop: 'myname'
+        },
         source: 'mysource',
         source_id: 'myid',
         bounding_box: '{"min_lat":12.121212,"max_lat":13.131313,"min_lon":21.212121,"max_lon":31.313131}',
@@ -57,19 +62,17 @@ module.exports.tests.toESDocument = function(test) {
 
     // test that empty arrays/object are stripped from the doc before sending it
     // downstream to elasticsearch.
-    t.false(esDoc.data.hasOwnProperty('address_parts'), 'does not include empty top-level maps');
-    t.false(esDoc.data.hasOwnProperty('category'), 'does not include empty top-level arrays');
-    t.false(esDoc.data.hasOwnProperty('parent'), 'does not include empty parent arrays');
     t.end();
   });
 
   test('unset properties should not output in toESDocument', (t) => {
-    var Document = proxyquire('../../Document', { 'pelias-config': fakeConfig });
+    const Document = proxyquire('../../Document', { 'pelias-config': fakeConfig });
 
-    var doc = new Document('mysource','mylayer','myid');
+    const esDoc = new Document('mysource','mylayer','myid').toESDocument();
 
-    var esDoc = doc.toESDocument();
-
+    t.false(esDoc.data.hasOwnProperty('address_parts'), 'does not include empty top-level maps');
+    t.false(esDoc.data.hasOwnProperty('category'), 'does not include empty top-level arrays');
+    t.false(esDoc.data.hasOwnProperty('parent'), 'does not include empty parent arrays');
     t.false(esDoc.data.hasOwnProperty('bounding_box'), 'should not include bounding_box');
     t.false(esDoc.data.hasOwnProperty('center_point'), 'should not include center');
     t.false(esDoc.data.hasOwnProperty('population'), ' should not include population');

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -20,6 +20,17 @@ module.exports.tests.toESDocument = function(test) {
     var Document = proxyquire('../../Document', { 'pelias-config': fakeConfig });
 
     var doc = new Document('mysource','mylayer','myid');
+    doc.setBoundingBox({
+      upperLeft: {
+        lat: 13.131313,
+        lon: 21.212121
+      },
+      lowerRight: {
+        lat: 12.121212,
+        lon: 31.313131
+      }
+    });
+
     var esDoc = doc.toESDocument();
 
     var expected = {
@@ -32,7 +43,8 @@ module.exports.tests.toESDocument = function(test) {
         name: {},
         phrase: {},
         source: 'mysource',
-        source_id: 'myid'
+        source_id: 'myid',
+        bounding_box: '{"min_lat":12.121212,"max_lat":13.131313,"min_lon":21.212121,"max_lon":31.313131}'
       }
     };
 

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -21,6 +21,10 @@ module.exports.tests.toESDocument = function(test) {
 
     var doc = new Document('mysource','mylayer','myid');
     doc.setName('myprop', 'myname');
+    doc.setAddress('name', 'address name');
+    doc.setAddress('number', 'address number');
+    doc.setAddress('street', 'address street');
+    doc.setAddress('zip', 'address zip');
     doc.setBoundingBox({
       upperLeft: {
         lat: 13.131313,
@@ -34,6 +38,8 @@ module.exports.tests.toESDocument = function(test) {
     doc.setPopulation(123);
     doc.setPopularity(456);
     doc.setPolygon({ key: 'value' });
+    doc.addCategory('category 1');
+    doc.addCategory('category 2');
 
     var esDoc = doc.toESDocument();
 
@@ -49,12 +55,24 @@ module.exports.tests.toESDocument = function(test) {
         phrase: {
           myprop: 'myname'
         },
+        address_parts: {
+          name: 'address name',
+          number: 'address number',
+          street: 'address street',
+          zip: 'address zip'
+        },
         source: 'mysource',
         source_id: 'myid',
         bounding_box: '{"min_lat":12.121212,"max_lat":13.131313,"min_lon":21.212121,"max_lon":31.313131}',
         population: 123,
         popularity: 456,
-        polygon: { key: 'value' }
+        polygon: {
+          key: 'value'
+        },
+        category: [
+          'category 1',
+          'category 2'
+        ]
       }
     };
 


### PR DESCRIPTION
- added `bounding_box` conditionally to output (was missing entirely)
- remove `center_point` from output when not set (previous behavior)
- added `population` conditionally to output (was missing entirely)
- added `popularity` conditionally to output (was missing entirely)
- added `polygon` conditionally to output (was missing entirely)
