### PR TITLE
assigned BUILD_LEADER_ID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ node_js:
 matrix:
   fast_finish: true
 env:
-  - BUILD_LEADER_ID=2
   global:
+    - BUILD_LEADER_ID=2
     - CXX=g++-4.8
 script: npm run travis
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
 matrix:
   fast_finish: true
 env:
+  - BUILD_LEADER_ID=2
   global:
     - CXX=g++-4.8
 script: npm run travis


### PR DESCRIPTION
set to `2` so semantic release will run after the node 6 build.  