### PR TITLE
Turn off building of version tags on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ before_script:
 after_success:
   - npm install -g npx
   - npx -p node@8 npm run semantic-release
+branches:
+  except:
+    - /^v\d+\.\d+\.\d+$/


### PR DESCRIPTION
These are redundant to build since they always correspond to an existing
commit from master. Turning off the builds saves slots on Travis for
other stuff to run.