### PR TITLE
Drop Node.js 4, add Node.js 8 and 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ notifications:
   email: false
 node_js:
   - 6
+  - 8
 matrix:
   fast_finish: true
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 notifications:
   email: false
 node_js:
-  - 4
   - 6
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ notifications:
 node_js:
   - 6
   - 8
+  - 10
 matrix:
   fast_finish: true
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,24 +8,13 @@ node_js:
   - 10
 matrix:
   fast_finish: true
-env:
-  global:
-    - BUILD_LEADER_ID=2
-    - CXX=g++-4.8
 script: npm run travis
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
 before_install:
-  - npm i -g npm@^3.0.0
+  - npm i -g npm
 before_script:
   - npm prune
 after_success:
-  - npm install -g npx
-  - npx -p node@8 npm run semantic-release
+  - npm run semantic-release
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ npm test
 
 ### Continuous Integration
 
-Travis tests every release against Node.js versions `4` and `6`.
+Travis tests every release against all supported Node.js versions.
 
 [![Build Status](https://travis-ci.org/pelias/model.png?branch=master)](https://travis-ci.org/pelias/model)
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/pelias/model/issues"
   },
   "engines": {
-    "node": ">= 4.0.0",
+    "node": ">= 6.0.0",
     "npm": ">=1.4.3"
   },
   "dependencies": {


### PR DESCRIPTION
Doing our usual upgrade dance for Node.js versions.

This also cleans up some old TravisCI settings.

Connects https://github.com/pelias/pelias/issues/693
Connects https://github.com/pelias/pelias/issues/612
Connects https://github.com/pelias/pelias/issues/723