### PR TITLE
Use carat ranges for all Pelias Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "lodash": "^4.6.1",
-    "pelias-config": "3.0.2",
+    "pelias-config": "^3.0.2",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The overhead of having to merge a Greenkeeper PR for every single change to
every single repository (which leads to cascading PRs) is too much.

Connects https://github.com/pelias/pelias/issues/366