### PR TITLE
chore(test): Use dedicated test script to catch errors

### DIFF
--- a/bin/units
+++ b/bin/units
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run tests with pipefail to avoid false passes
+# see https://github.com/pelias/pelias/issues/744
+set -o pipefail
+
+node test/run.js | npx tap-spec

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
-    "units": "node test/run.js | tap-spec",
+    "units": "./bin/units",
     "test": "npm run units",
     "travis": "npm test",
     "lint": "jshint .",


### PR DESCRIPTION
The way we were running our unit tests does not catch fatal errors in
the unit test run, even though they return non-zero status codes.

By using a dedicated script to run the tests, with the `pipefail`
option, we can catch them.

Connects https://github.com/pelias/pelias/issues/744