### PR TITLE
support common intersection syntactic variations

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -72,7 +72,7 @@ Document.prototype.removePostProcessingScript = function( fn ){
 
 // call all post-processing scripts
 Document.prototype.callPostProcessingScripts = function(){
-  this._post.forEach(function(fn){ fn.call(this); }, this);
+  this._post.forEach(function(fn){ fn.call(null, this); }, this);
   return this;
 };
 

--- a/post/intersections.js
+++ b/post/intersections.js
@@ -4,32 +4,32 @@ const INTERSECTION_LAYER_NAME = 'intersection';
 const ADDRESS_STREET_PROP = 'street';
 const ADDRESS_CROSS_STREET_PROP = 'cross_street';
 
-function intersections(){
+function intersections( doc ){
 
   // only apply to docs from the intersection layer
-  if( this.getLayer() !== INTERSECTION_LAYER_NAME ){ return; }
+  if( doc.getLayer() !== INTERSECTION_LAYER_NAME ){ return; }
 
   // ensure both street & cross street props are set
-  let street = this.getAddress(ADDRESS_STREET_PROP);
+  let street = doc.getAddress(ADDRESS_STREET_PROP);
   if( !_.isString(street) || _.isEmpty(street) ){ return; }
   
-  let cross_street = this.getAddress(ADDRESS_CROSS_STREET_PROP);
+  let cross_street = doc.getAddress(ADDRESS_CROSS_STREET_PROP);
   if( !_.isString(cross_street) || _.isEmpty(cross_street) ){ return; }
 
   // generate name aliases for the intersection based on common syntactic variations.
   // note: currently only english is supported, PRs for additional languages welcome.
 
   // corner of A & B
-  this.setNameAlias('default', `${street} & ${cross_street}`);
-  this.setNameAlias('default', `${street} @ ${cross_street}`);
-  this.setNameAlias('default', `${street} at ${cross_street}`);
-  this.setNameAlias('default', `Corner of ${street} & ${cross_street}`);
+  doc.setNameAlias('default', `${street} & ${cross_street}`);
+  doc.setNameAlias('default', `${street} @ ${cross_street}`);
+  doc.setNameAlias('default', `${street} at ${cross_street}`);
+  doc.setNameAlias('default', `Corner of ${street} & ${cross_street}`);
   
   // corner of B & A
-  this.setNameAlias('default', `${cross_street} & ${street}`);
-  this.setNameAlias('default', `${cross_street} @ ${street}`);
-  this.setNameAlias('default', `${cross_street} at ${street}`);
-  this.setNameAlias('default', `Corner of ${cross_street} & ${street}`);
+  doc.setNameAlias('default', `${cross_street} & ${street}`);
+  doc.setNameAlias('default', `${cross_street} @ ${street}`);
+  doc.setNameAlias('default', `${cross_street} at ${street}`);
+  doc.setNameAlias('default', `Corner of ${cross_street} & ${street}`);
 }
 
 module.exports = intersections;

--- a/post/intersections.js
+++ b/post/intersections.js
@@ -1,0 +1,35 @@
+const _ = require('lodash');
+
+const INTERSECTION_LAYER_NAME = 'intersection';
+const ADDRESS_STREET_PROP = 'street';
+const ADDRESS_CROSS_STREET_PROP = 'cross_street';
+
+function intersections(){
+
+  // only apply to docs from the intersection layer
+  if( this.getLayer() !== INTERSECTION_LAYER_NAME ){ return; }
+
+  // ensure both street & cross street props are set
+  let street = this.getAddress(ADDRESS_STREET_PROP);
+  if( !_.isString(street) || _.isEmpty(street) ){ return; }
+  
+  let cross_street = this.getAddress(ADDRESS_CROSS_STREET_PROP);
+  if( !_.isString(cross_street) || _.isEmpty(cross_street) ){ return; }
+
+  // generate name aliases for the intersection based on common syntactic variations.
+  // note: currently only english is supported, PRs for additional languages welcome.
+
+  // corner of A & B
+  this.setNameAlias('default', `${street} & ${cross_street}`);
+  this.setNameAlias('default', `${street} @ ${cross_street}`);
+  this.setNameAlias('default', `${street} at ${cross_street}`);
+  this.setNameAlias('default', `Corner of ${street} & ${cross_street}`);
+  
+  // corner of B & A
+  this.setNameAlias('default', `${cross_street} & ${street}`);
+  this.setNameAlias('default', `${cross_street} @ ${street}`);
+  this.setNameAlias('default', `${cross_street} at ${street}`);
+  this.setNameAlias('default', `Corner of ${cross_street} & ${street}`);
+}
+
+module.exports = intersections;

--- a/test/document/post.js
+++ b/test/document/post.js
@@ -1,0 +1,95 @@
+
+const Document = require('../../Document');
+const intersections = require('../../post/intersections');
+const DEFAULT_SCRIPTS = [ intersections ];
+
+module.exports.tests = {};
+
+module.exports.tests.addPostProcessingScript = function(test) {
+  test('default scripts', function(t) {
+    let doc = new Document('mysource','mylayer','myid');
+    t.deepEqual(doc._post, DEFAULT_SCRIPTS, 'default processing scripts');
+    t.end();
+  });
+  test('invalid type', function(t) {
+    let doc = new Document('mysource','mylayer','myid');
+    t.throws( doc.addPostProcessingScript.bind(doc, 'invalid'), /invalid document type, expecting: function got/ );
+    t.throws( doc.addPostProcessingScript.bind(doc, 100), /invalid document type, expecting: function got/ );
+    t.throws( doc.addPostProcessingScript.bind(doc, []), /invalid document type, expecting: function got/ );
+    t.throws( doc.addPostProcessingScript.bind(doc, {}), /invalid document type, expecting: function got/ );
+    t.end();
+  });
+  test('set function', function(t) {
+    let script = function(){};
+    let doc = new Document('mysource','mylayer','myid');
+    doc.addPostProcessingScript( script );
+    t.deepEqual(doc._post, DEFAULT_SCRIPTS.concat( script ), 'default processing scripts');
+    t.end();
+  });
+  test('set same function twice (allowed)', function(t) {
+    let script = function(){};
+    let doc = new Document('mysource','mylayer','myid');
+    doc.addPostProcessingScript( script );
+    doc.addPostProcessingScript( script );
+    t.deepEqual(doc._post, DEFAULT_SCRIPTS.concat( script, script ), 'default processing scripts');
+    t.end();
+  });
+};
+
+module.exports.tests.removePostProcessingScript = function(test) {
+  test('invalid type', function(t) {
+    let doc = new Document('mysource','mylayer','myid');
+    t.throws( doc.removePostProcessingScript.bind(doc, 'invalid'), /invalid document type, expecting: function got/ );
+    t.throws( doc.removePostProcessingScript.bind(doc, 100), /invalid document type, expecting: function got/ );
+    t.throws( doc.removePostProcessingScript.bind(doc, []), /invalid document type, expecting: function got/ );
+    t.throws( doc.removePostProcessingScript.bind(doc, {}), /invalid document type, expecting: function got/ );
+    t.end();
+  });
+  test('remove function', function(t) {
+    let script = function(){};
+    let doc = new Document('mysource','mylayer','myid');
+    doc._post = [ script ];
+    doc.removePostProcessingScript( script );
+    t.deepEqual(doc._post, [], 'script removed');
+    doc.removePostProcessingScript( script );
+    t.deepEqual(doc._post, [], 'no-op');
+    t.end();
+  });
+  test('remove duplicate functions (allowed)', function(t) {
+    let script = function(){};
+    let doc = new Document('mysource','mylayer','myid');
+    doc._post = [ script, script ];
+    doc.removePostProcessingScript( script );
+    t.deepEqual(doc._post, [], 'scripts removed');
+    doc.removePostProcessingScript( script );
+    t.deepEqual(doc._post, [], 'no-op');
+    t.end();
+  });
+};
+
+module.exports.tests.callPostProcessingScript = function(test) {
+  test('call all scripts', function(t) {
+    let doc = new Document('mysource','mylayer','myid');
+    doc._post = []; // remove any default scripts
+    t.plan(3);
+
+    // document pointer passed as first arg to scripts
+    doc.addPostProcessingScript((ref) => t.equal(doc, ref));
+    doc.addPostProcessingScript((ref) => t.equal(doc, ref));
+    doc.addPostProcessingScript((ref) => t.equal(doc, ref));
+
+    // call all scripts
+    doc.callPostProcessingScripts();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('post processing: ' + name, testFunction);
+  }
+
+  for( let testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -217,6 +217,23 @@ module.exports.tests.toESDocumentWithCustomConfig = function(test) {
   });
 };
 
+module.exports.tests.toESDocumentCallsProcessingScripts = function(test) {
+  test('toESDocument must call all post-processing scripts', function(t) {
+    let Document = proxyquire('../../Document', { 'pelias-config': fakeConfig });
+    let doc = new Document('mysource','mylayer','myid');
+    doc._post = []; // remove any default scripts
+    t.plan(3);
+
+    // document pointer passed as first arg to scripts
+    doc.addPostProcessingScript((ref) => t.equal(doc, ref));
+    doc.addPostProcessingScript((ref) => t.equal(doc, ref));
+    doc.addPostProcessingScript((ref) => t.equal(doc, ref));
+
+    // toESDocument() should, in tern, call callPostProcessingScripts()
+    doc.toESDocument();
+  });
+};
+
 module.exports.all = function (tape, common) {
   function test(name, testFunction) {
     return tape('Document: ' + name, testFunction);

--- a/test/post/intersections.js
+++ b/test/post/intersections.js
@@ -1,0 +1,45 @@
+
+var Document = require('../../Document');
+var intersections = require('../../post/intersections');
+
+module.exports.tests = {};
+
+module.exports.tests.functional = function(test) {
+  test('functional', function(t) {
+    var doc = new Document('mysource','intersection','myid');
+    
+    // street and cross_street not set
+    intersections.call(doc);
+    t.deepEqual(doc.getNameAliases('default'), [], 'no names set');
+
+    // street and cross_street set
+    doc.setAddress('street', 'Example Street');
+    doc.setAddress('cross_street', 'Cross Street');
+    intersections.call(doc);
+
+    // intersection aliases defined
+    t.deepEqual(doc.getNameAliases('default'), [
+      'Example Street & Cross Street',
+      'Example Street @ Cross Street',
+      'Example Street at Cross Street',
+      'Corner of Example Street & Cross Street',
+      'Cross Street & Example Street',
+      'Cross Street @ Example Street',
+      'Cross Street at Example Street',
+      'Corner of Cross Street & Example Street'
+    ]);
+
+    t.end();
+  });
+};
+
+module.exports.all = function (tape, common) {
+
+  function test(name, testFunction) {
+    return tape('post/intersections: ' + name, testFunction);
+  }
+
+  for( var testCase in module.exports.tests ){
+    module.exports.tests[testCase](test, common);
+  }
+};

--- a/test/post/intersections.js
+++ b/test/post/intersections.js
@@ -12,9 +12,17 @@ module.exports.tests.functional = function(test) {
     intersections.call(doc);
     t.deepEqual(doc.getNameAliases('default'), [], 'no names set');
 
-    // street and cross_street set
+    // set street
     doc.setAddress('street', 'Example Street');
+
+    // street set, cross_street not set
+    intersections.call(doc);
+    t.deepEqual(doc.getNameAliases('default'), [], 'no names set');
+
+    // set cross_street
     doc.setAddress('cross_street', 'Cross Street');
+
+    // street and cross_street set
     intersections.call(doc);
 
     // intersection aliases defined

--- a/test/post/intersections.js
+++ b/test/post/intersections.js
@@ -9,21 +9,21 @@ module.exports.tests.functional = function(test) {
     var doc = new Document('mysource','intersection','myid');
     
     // street and cross_street not set
-    intersections.call(doc);
+    intersections(doc);
     t.deepEqual(doc.getNameAliases('default'), [], 'no names set');
 
     // set street
     doc.setAddress('street', 'Example Street');
 
     // street set, cross_street not set
-    intersections.call(doc);
+    intersections(doc);
     t.deepEqual(doc.getNameAliases('default'), [], 'no names set');
 
     // set cross_street
     doc.setAddress('cross_street', 'Cross Street');
 
     // street and cross_street set
-    intersections.call(doc);
+    intersections(doc);
 
     // intersection aliases defined
     t.deepEqual(doc.getNameAliases('default'), [

--- a/test/run.js
+++ b/test/run.js
@@ -22,6 +22,7 @@ var tests = [
   require('./document/layer.js'),
   require('./document/source_id.js'),
   require('./document/toESDocument.js'),
+  require('./post/intersections.js'),
   require('./DocumentMapperStream.js'),
   require('./util/transform.js'),
   require('./util/valid.js'),

--- a/test/run.js
+++ b/test/run.js
@@ -22,6 +22,7 @@ var tests = [
   require('./document/layer.js'),
   require('./document/source_id.js'),
   require('./document/toESDocument.js'),
+  require('./document/post.js'),
   require('./post/intersections.js'),
   require('./DocumentMapperStream.js'),
   require('./util/transform.js'),


### PR DESCRIPTION
This PR improves support for intersection matching in Pelias.

It introduces a new `layer` called `intersection` as well as a new `address_parts` property called `cross_street`.

I've also added a new concept within the `pelias/model` code which allow registering of "post-processing scripts" which are executed within the `toESDocument` function before being converted to the ES schema format.

The `post/intersections.js` function I've added detects documents from the `intersection` layer and adds additional name aliases as such:

```js
  // corner of A & B
  doc.setNameAlias('default', `${street} & ${cross_street}`);
  doc.setNameAlias('default', `${street} @ ${cross_street}`);
  doc.setNameAlias('default', `${street} at ${cross_street}`);
  doc.setNameAlias('default', `Corner of ${street} & ${cross_street}`);
  
  // corner of B & A
  doc.setNameAlias('default', `${cross_street} & ${street}`);
  doc.setNameAlias('default', `${cross_street} @ ${street}`);
  doc.setNameAlias('default', `${cross_street} at ${street}`);
  doc.setNameAlias('default', `Corner of ${cross_street} & ${street}`);
``` 

There are a few changes here so I'd appreciate some feedback before merging this. We discussed other places in the codebase where this code might live but in the end, decided that it would be nice to have it in `pelias/model` so it can be used by any importer.

Intersection queries pose a few different issues, this PR will help improve the syntactic matching using name aliases, but it might be beneficial to address any vocab related issue in a `pelias/schema` PR (such as `at vs @` and other common punctuation variations).

WIP: waiting for feedback, ~~requires more unit tests to cover all functionality in PR (such as the 3 new methods on Document)~~