### PR TITLE
do not allow urls in name and address fields

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -255,6 +255,7 @@ Document.prototype.setName = function( prop, value ){
 
   validate.type('string', value);
   validate.truthy(value);
+  validate.regex.nomatch(value, /https?:\/\//);
 
   // must copy name to 'phrase' index
   if( Array.isArray( this.name[ prop ] ) ){
@@ -272,6 +273,7 @@ Document.prototype.setNameAlias = function( prop, value ){
 
   validate.type('string', value);
   validate.truthy(value);
+  validate.regex.nomatch(value, /https?:\/\//);
 
   // is this the first time setting this prop? ensure it's an array
   if( !this.hasName( prop ) ){
@@ -413,6 +415,7 @@ Document.prototype.setAddress = function( prop, value ){
   validate.type('string', value);
   validate.truthy(value);
   validate.property(addressFields, prop);
+  validate.regex.nomatch(value, /https?:\/\//);
 
   if( Array.isArray( this.address_parts[ prop ] ) ){
     this.address_parts[ prop ][ 0 ] = value;
@@ -428,6 +431,7 @@ Document.prototype.setAddressAlias = function( prop, value ){
   validate.type('string', value);
   validate.truthy(value);
   validate.property(addressFields, prop);
+  validate.regex.nomatch(value, /https?:\/\//);
 
   // is this the first time setting this prop? ensure it's an array
   if( !this.hasAddress( prop ) ){

--- a/test/document/address.js
+++ b/test/document/address.js
@@ -49,6 +49,12 @@ module.exports.tests.setAddress = function(test) {
     t.equal(doc.getAddress('test'), undefined, 'property not set');
     t.end();
   });
+  test('setAddress - http regex', function (t) {
+    var doc = new Document('mysource', 'mylayer', 'myid');
+    t.throws(doc.setAddress.bind(doc, 'number', 'http://www.pelias.io'), /invalid regex/, 'regex failure');
+    t.throws(doc.setAddress.bind(doc, 'number', 'AAhttp://www.pelias.ioBB'), /invalid regex/, 'regex failure');
+    t.end();
+  });
 };
 
 module.exports.tests.getAddressAliases = function(test) {
@@ -106,6 +112,12 @@ module.exports.tests.setAddressAlias = function(test) {
     t.throws( doc.setAddressAlias.bind(doc,'zip',null), null, 'invalid value' );
     t.throws( doc.setAddressAlias.bind(doc,'zip','\t'), null, 'invalid value' );
     t.deepEqual(doc.getAddressAliases('test'), [], 'property not set');
+    t.end();
+  });
+  test('setAddressAlias - http regex', function (t) {
+    var doc = new Document('mysource', 'mylayer', 'myid');
+    t.throws(doc.setAddressAlias.bind(doc, 'number', 'http://www.pelias.io'), /invalid regex/, 'regex failure');
+    t.throws(doc.setAddressAlias.bind(doc, 'number', 'AAhttp://www.pelias.ioBB'), /invalid regex/, 'regex failure');
     t.end();
   });
 };

--- a/test/document/name.js
+++ b/test/document/name.js
@@ -40,6 +40,12 @@ module.exports.tests.setName = function(test) {
     t.equal(doc.getName('test'), undefined, 'property not set');
     t.end();
   });
+  test('setName - http regex', function (t) {
+    var doc = new Document('mysource', 'mylayer', 'myid');
+    t.throws(doc.setName.bind(doc, 'default', 'http://www.pelias.io'), /invalid regex/, 'regex failure');
+    t.throws(doc.setName.bind(doc, 'default', 'AAhttp://www.pelias.ioBB'), /invalid regex/, 'regex failure');
+    t.end();
+  });
 };
 
 module.exports.tests.getNameAliases = function(test) {
@@ -103,6 +109,12 @@ module.exports.tests.setNameAlias = function(test) {
     t.throws( doc.setNameAlias.bind(doc,'test',null), null, 'invalid value' );
     t.throws( doc.setNameAlias.bind(doc,'test','\t'), null, 'invalid value' );
     t.deepEqual(doc.getNameAliases('test'), [], 'property not set');
+    t.end();
+  });
+  test('setNameAlias - http regex', function (t) {
+    var doc = new Document('mysource', 'mylayer', 'myid');
+    t.throws(doc.setNameAlias.bind(doc, 'default', 'http://www.pelias.io'), /invalid regex/, 'regex failure');
+    t.throws(doc.setNameAlias.bind(doc, 'default', 'AAhttp://www.pelias.ioBB'), /invalid regex/, 'regex failure');
     t.end();
   });
 };

--- a/test/util/valid.js
+++ b/test/util/valid.js
@@ -20,6 +20,14 @@ module.exports.tests.nonnegative = (test) => {
 
 };
 
+module.exports.tests.regex = (test) => {
+  test('regex nomatch', (t) => {
+    t.throws(valid.regex.nomatch.bind(null, 'hello', /he/), /invalid regex/);
+    t.doesNotThrow(valid.regex.nomatch.bind(null, 'hello', /bye/), /invalid regex/);
+    t.end();
+  });
+};
+
 module.exports.all = (tape, common) => {
 
   function test(name, testFunction) {

--- a/util/valid.js
+++ b/util/valid.js
@@ -110,3 +110,13 @@ module.exports.boundingBox = function( val ) {
   
   return this;
 };
+
+module.exports.regex = {
+  nomatch: function(val, regex) {
+    if( regex.test(val) ){
+      throw new PeliasModelError(`invalid regex test, ${val} should not match ${regex}`);
+    }
+
+    return module.exports;
+  }
+};


### PR DESCRIPTION
We recently discovered some open-data which incorrectly contains URLs in the `name` & `housenumber` fields.
Unfortunately, this seems to be a common problem in openstreetmap due to human error.

This PR enforces a regex check on `name` and `address` fields to ensure that they do not contain URLs.