### PR TITLE
tests(document-mapper) move away from event-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "through2": "^3.0.0"
   },
   "devDependencies": {
-    "event-stream": "^4.0.0",
+    "stream-mock": "^2.0.3",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^2.0.0",
     "tap-spec": "^5.0.0",


### PR DESCRIPTION
Replacing event-stream with stream-mock as discussed in pelias/pelias#801