### PR TITLE
Store GID in Elasticsearch _id field

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -143,7 +143,7 @@ Document.prototype.toESDocument = function() {
   return {
     _index: config.schema.indexName,
     _type: this.getType(),
-    _id: this.getId(),
+    _id: this.getGid(),
     data: doc
   };
 };

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -50,7 +50,7 @@ module.exports.tests.toESDocument = function(test) {
     var expected = {
       _index: 'pelias',
       _type: 'mylayer',
-      _id: 'myid',
+      _id: 'mysource:mylayer:myid',
       data: {
         layer: 'mylayer',
         name: {
@@ -102,7 +102,7 @@ module.exports.tests.toESDocument = function(test) {
     var expected = {
       _index: 'pelias',
       _type: 'mylayer',
-      _id: 'myid',
+      _id: 'mysource:mylayer:myid',
       data: {
         source: 'mysource',
         layer: 'mylayer',
@@ -156,7 +156,7 @@ module.exports.tests.toESDocument = function(test) {
     var expected = {
       _index: 'pelias',
       _type: 'mylayer',
-      _id: 'myid',
+      _id: 'mysource:mylayer:myid',
       data: {
         source: 'mysource',
         layer: 'mylayer',


### PR DESCRIPTION
BREAKING CHANGE: The Pelias GID is now stored in Elasticsearch's `_id` field, in order to remove the potential for two different documents to conflict with the previous mapping.

pelias/api v3.79.0 (d5f4e411) is required to support this change.

This implements step 3 in https://github.com/pelias/pelias/issues/672#issuecomment-508837195

Connects https://github.com/pelias/pelias/issues/672
Connects https://github.com/pelias/pelias/issues/719