### PR TITLE
do not throw on name/address regex matching errors

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -245,7 +245,7 @@ Document.prototype.setName = function( prop, value ){
 
   validate.type('string', value);
   validate.truthy(value);
-  validate.regex.nomatch(value, /https?:\/\//);
+  validate.regex.nomatch(value, /https?:\/\//, { throw: false });
 
   // must copy name to 'phrase' index
   if( Array.isArray( this.name[ prop ] ) ){
@@ -263,7 +263,7 @@ Document.prototype.setNameAlias = function( prop, value ){
 
   validate.type('string', value);
   validate.truthy(value);
-  validate.regex.nomatch(value, /https?:\/\//);
+  validate.regex.nomatch(value, /https?:\/\//, { throw: false });
 
   // is this the first time setting this prop? ensure it's an array
   if( !this.hasName( prop ) ){
@@ -405,7 +405,7 @@ Document.prototype.setAddress = function( prop, value ){
   validate.type('string', value);
   validate.truthy(value);
   validate.property(addressFields, prop);
-  validate.regex.nomatch(value, /https?:\/\//);
+  validate.regex.nomatch(value, /https?:\/\//, { throw: false });
 
   if( Array.isArray( this.address_parts[ prop ] ) ){
     this.address_parts[ prop ][ 0 ] = value;
@@ -421,7 +421,7 @@ Document.prototype.setAddressAlias = function( prop, value ){
   validate.type('string', value);
   validate.truthy(value);
   validate.property(addressFields, prop);
-  validate.regex.nomatch(value, /https?:\/\//);
+  validate.regex.nomatch(value, /https?:\/\//, { throw: false });
 
   // is this the first time setting this prop? ensure it's an array
   if( !this.hasAddress( prop ) ){

--- a/test/document/address.js
+++ b/test/document/address.js
@@ -49,10 +49,10 @@ module.exports.tests.setAddress = function(test) {
     t.equal(doc.getAddress('test'), undefined, 'property not set');
     t.end();
   });
-  test('setAddress - http regex', function (t) {
+  test('setAddress - http regex - throw false', function (t) {
     var doc = new Document('mysource', 'mylayer', 'myid');
-    t.throws(doc.setAddress.bind(doc, 'number', 'http://www.pelias.io'), /invalid regex/, 'regex failure');
-    t.throws(doc.setAddress.bind(doc, 'number', 'AAhttp://www.pelias.ioBB'), /invalid regex/, 'regex failure');
+    t.doesNotThrow(doc.setAddress.bind(doc, 'number', 'http://www.pelias.io'), /invalid regex/, 'regex failure');
+    t.doesNotThrow(doc.setAddress.bind(doc, 'number', 'AAhttp://www.pelias.ioBB'), /invalid regex/, 'regex failure');
     t.end();
   });
 };
@@ -114,10 +114,18 @@ module.exports.tests.setAddressAlias = function(test) {
     t.deepEqual(doc.getAddressAliases('test'), [], 'property not set');
     t.end();
   });
-  test('setAddressAlias - http regex', function (t) {
+  test('setAddressAlias - http regex - throw false', function (t) {
     var doc = new Document('mysource', 'mylayer', 'myid');
-    t.throws(doc.setAddressAlias.bind(doc, 'number', 'http://www.pelias.io'), /invalid regex/, 'regex failure');
-    t.throws(doc.setAddressAlias.bind(doc, 'number', 'AAhttp://www.pelias.ioBB'), /invalid regex/, 'regex failure');
+    t.doesNotThrow(
+      doc.setAddressAlias.bind(doc, 'number', 'http://www.pelias.io'),
+      /invalid regex/,
+      'regex failure'
+    );
+    t.doesNotThrow(
+      doc.setAddressAlias.bind(doc, 'number', 'AAhttp://www.pelias.ioBB'),
+      /invalid regex/,
+      'regex failure'
+    );
     t.end();
   });
 };

--- a/test/document/name.js
+++ b/test/document/name.js
@@ -40,10 +40,10 @@ module.exports.tests.setName = function(test) {
     t.equal(doc.getName('test'), undefined, 'property not set');
     t.end();
   });
-  test('setName - http regex', function (t) {
+  test('setName - http regex - throw false', function (t) {
     var doc = new Document('mysource', 'mylayer', 'myid');
-    t.throws(doc.setName.bind(doc, 'default', 'http://www.pelias.io'), /invalid regex/, 'regex failure');
-    t.throws(doc.setName.bind(doc, 'default', 'AAhttp://www.pelias.ioBB'), /invalid regex/, 'regex failure');
+    t.doesNotThrow(doc.setName.bind(doc, 'default', 'http://www.pelias.io'), /invalid regex/, 'regex failure');
+    t.doesNotThrow(doc.setName.bind(doc, 'default', 'AAhttp://www.pelias.ioBB'), /invalid regex/, 'regex failure');
     t.end();
   });
 };
@@ -111,10 +111,10 @@ module.exports.tests.setNameAlias = function(test) {
     t.deepEqual(doc.getNameAliases('test'), [], 'property not set');
     t.end();
   });
-  test('setNameAlias - http regex', function (t) {
+  test('setNameAlias - http regex - throw false', function (t) {
     var doc = new Document('mysource', 'mylayer', 'myid');
-    t.throws(doc.setNameAlias.bind(doc, 'default', 'http://www.pelias.io'), /invalid regex/, 'regex failure');
-    t.throws(doc.setNameAlias.bind(doc, 'default', 'AAhttp://www.pelias.ioBB'), /invalid regex/, 'regex failure');
+    t.doesNotThrow(doc.setNameAlias.bind(doc, 'default', 'http://www.pelias.io'), /invalid regex/, 'regex failure');
+    t.doesNotThrow(doc.setNameAlias.bind(doc, 'default', 'AAhttp://www.pelias.ioBB'), /invalid regex/, 'regex failure');
     t.end();
   });
 };

--- a/test/util/valid.js
+++ b/test/util/valid.js
@@ -26,6 +26,12 @@ module.exports.tests.regex = (test) => {
     t.doesNotThrow(valid.regex.nomatch.bind(null, 'hello', /bye/), /invalid regex/);
     t.end();
   });
+
+  test('regex nomatch - throw false', (t) => {
+    const options = { throw: false };
+    t.doesNotThrow(valid.regex.nomatch.bind(null, 'hello', /he/, options), /invalid regex/);
+    t.end();
+  });
 };
 
 module.exports.all = (tape, common) => {

--- a/util/valid.js
+++ b/util/valid.js
@@ -1,6 +1,6 @@
 
-var _ = require('lodash'),
-    PeliasModelError = require('../errors').PeliasModelError;
+const _ = require('lodash');
+const PeliasModelError = require('../errors').PeliasModelError;
 
 module.exports.type = function( type, val ){
   if( type.toLowerCase() === 'array' ){
@@ -112,9 +112,14 @@ module.exports.boundingBox = function( val ) {
 };
 
 module.exports.regex = {
-  nomatch: function(val, regex) {
+  nomatch: function(val, regex, options) {
     if( regex.test(val) ){
-      throw new PeliasModelError(`invalid regex test, ${val} should not match ${regex}`);
+      const message = `invalid regex test, ${val} should not match ${regex}`;
+      if( _.get(options, 'throw', true) === false ){
+        console.warn(message);
+      } else {
+        throw new PeliasModelError(message);
+      }
     }
 
     return module.exports;


### PR DESCRIPTION
this is one solution to the verbose regex matching errors.

we've had a lot of users worried and confused about the verbose errors we return when the source data for a name or address erroneously contains a URL.

there are a few ways of dealing with it, I considered returning a `PeliasModelWarning` error but solutions like that require that each importer is updated and it's not nice code because throwing will terminate the current scope, necessitating that each setter is wrapped in its own `catch` block 💩 

this solution is fairly clean, I'm still outputting the error message via `console.warn` and considered using `pelias-logger` although I'd prefer to reduce the coupling to other modules to this one to avoid the 'bump cascades'.