### PR TITLE
support for dynamically specifying the elasticsearch _type from config

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -141,12 +141,12 @@ Document.prototype.toESDocument = function() {
   }
 
   return {
-    _index: config.schema.indexName,
+    _index: _.get(config, 'schema.indexName', 'pelias'),
     _id: this.getGid(),
     // In ES7, the only allowed document type will be `_doc`.
     // However underscores are not allowed until ES6, so use `doc` for now
     // see https://github.com/elastic/elasticsearch/pull/27816
-    _type: 'doc',
+    _type: _.get(config, 'schema.typeName', 'doc'),
     data: doc
   };
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "lodash": "^4.6.1",
-    "pelias-config": "^4.0.0",
+    "pelias-config": "^4.5.0",
     "through2": "^3.0.0"
   },
   "devDependencies": {

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -3,7 +3,8 @@ const codec = require('../../codec');
 
 var fakeGeneratedConfig = {
   schema: {
-    indexName: 'pelias'
+    indexName: 'example_index',
+    typeName: 'example_type'
   }
 };
 
@@ -48,8 +49,8 @@ module.exports.tests.toESDocument = function(test) {
     var esDoc = doc.toESDocument();
 
     var expected = {
-      _index: 'pelias',
-      _type: 'doc',
+      _index: 'example_index',
+      _type: 'example_type',
       _id: 'mysource:mylayer:myid',
       data: {
         layer: 'mylayer',
@@ -100,8 +101,8 @@ module.exports.tests.toESDocument = function(test) {
     var esDoc = doc.toESDocument();
 
     var expected = {
-      _index: 'pelias',
-      _type: 'doc',
+      _index: 'example_index',
+      _type: 'example_type',
       _id: 'mysource:mylayer:myid',
       data: {
         source: 'mysource',
@@ -154,8 +155,8 @@ module.exports.tests.toESDocument = function(test) {
     var esDoc = doc.toESDocument();
 
     var expected = {
-      _index: 'pelias',
-      _type: 'doc',
+      _index: 'example_index',
+      _type: 'example_type',
       _id: 'mysource:mylayer:myid',
       data: {
         source: 'mysource',


### PR DESCRIPTION
this pairs with https://github.com/pelias/config/pull/118
the motivation is being *able to* create indices compatible with ES7 while not yet breaking backwards support for ES5.

this allows us to create ES7 compatible indices using either ES6 or ES7 without breaking backwards compatibility with 5 yet.

the major motivation for this is that users currently building on `pelias/docker` on ES6 are going to find that the indices they created with ES6 (using `_type:doc`) are incompatible with ES7 (and also incompatible with ES6 once we change the type name to `_doc`!)

that doesn't really make sense, so I plan to set the `config.schema.typeName` variable to `_doc` in `pelias/docker` projects so that indices built with ES6 will not incur any breaking changes.

this is much preferred because without it any users migrating to ES6 would assume that in doing so they were avoiding breaking changes when in fact that wasn't true.

