### PR TITLE
Support custom source for parents

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,7 +16,7 @@
   "quotmark": "single",
   "undef": true,
   "unused": true,
-  "maxparams": 4,
+  "maxparams": 6,
   "maxdepth": 4,
   "maxlen": 120
 }

--- a/Document.js
+++ b/Document.js
@@ -317,7 +317,7 @@ Document.prototype.delName = function( prop ){
 };
 
 // parent
-Document.prototype.addParent = function( field, name, id, abbr ){
+Document.prototype.addParent = function( field, name, id, abbr, source ){
 
   var add = function( prop, value ){
 
@@ -373,6 +373,12 @@ Document.prototype.addParent = function( field, name, id, abbr ){
     add( field + '_a', null );
   }
 
+  if (typeof source === 'string') {
+    addValidate( field + '_source', source );
+  } else {
+    add( field + '_source', null );
+  }
+
   // chainable
   return this;
 };
@@ -388,6 +394,7 @@ Document.prototype.clearParent = function(field) {
   this.parent[ field ] = [];
   this.parent[ field + '_id' ] = [];
   this.parent[ field + '_a' ] = [];
+  this.parent[ field + '_source' ] = [];
 
   return this;
 };

--- a/test/serialize/test.js
+++ b/test/serialize/test.js
@@ -50,6 +50,7 @@ module.exports.tests.complete = function(test) {
       .setName( 'alt', 'Haggerston City Farm' )
       .addParent( 'country', 'Great Britain', '1001', 'GreatB' )
       .addParent( 'neighbourhood', 'Shoreditch', '2002' )
+      .addParent( 'locality', 'London', '3003', 'LD', 'whosonfirst' )
       .setAddress( 'number', '10' )
       .setAddress( 'street', 'pelias place' )
       .addCategory( 'foo' )
@@ -98,9 +99,15 @@ module.exports.tests.complete = function(test) {
         'country': ['Great Britain'],
         'country_a': ['GreatB'],
         'country_id': ['1001'],
+        'country_source': [null],
         'neighbourhood': ['Shoreditch'],
         'neighbourhood_a': [null],
-        'neighbourhood_id': ['2002']
+        'neighbourhood_id': ['2002'],
+        'neighbourhood_source': [null],
+        'locality': ['London'],
+        'locality_a': ['LD'],
+        'locality_id': ['3003'],
+        'locality_source': ['whosonfirst']
       },
 
       // geography


### PR DESCRIPTION
## Background

At the time of this PR, when we build the hierarchy, we use [pelias/pip-service](https://github.com/pelias/pip-service) which is an In Memory Point-In-Polygon lookup service based on WOF data. That means, when we have something in the hierarchy, it's necessarily from WOF.
As a result, in the API, when we retrieve data from PIP Service, the source WOF is [hard-codded](https://github.com/pelias/api/blob/76a31d96d092dc67005a994728941ca739ed3bec/controller/coarse_reverse.js#L70).

The future of PIP is [pelias/spatial](https://github.com/pelias/spatial) which supports a plethora of sources. I start the work for a smooth integration from the beginning.

## What's new ?

Since spatial is not yet used, the source will always be `null` and the code is 100% backward compatible. ~~I changed the fourth parameter to an object because the linter says : `Document.js: line 319, col 40, This function has too many parameters. (5)` for a new parameter.
If the fourth parameter is a string, that means that it's an abbreviation, and if it's an object, it should contains abbr and/or source.~~
I added a fifth parameter for the source.