### PR TITLE
fix(deduplication): Deduplicate values in phrase field

### DIFF
--- a/post/deduplication.js
+++ b/post/deduplication.js
@@ -4,7 +4,7 @@
  */
 
 const _ = require('lodash');
-const prefixes = [ 'name', 'address_parts' ];
+const prefixes = [ 'name', 'phrase', 'address_parts' ];
 
 function deduplication( doc ){
   prefixes.forEach(prefix => {

--- a/test/post/deduplication.js
+++ b/test/post/deduplication.js
@@ -33,6 +33,21 @@ module.exports.tests.dedupe = function (test) {
 
     t.end();
   });
+
+  test('dedupe - phrase', function (t) {
+    var doc = new Document('mysource', 'mylayer', 'myid');
+
+    doc.setNameAlias('default', 'test');
+    doc.setName('default', 'test');
+    doc.setNameAlias('default', 'test');
+    doc.setNameAlias('default', 'test 2');
+    doc.setNameAlias('default', 'test');
+
+    deduplication(doc);
+    t.deepEquals(doc.phrase.default, ['test', 'test 2']);
+
+    t.end();
+  });
 };
 
 module.exports.all = function (tape, common) {


### PR DESCRIPTION
https://github.com/pelias/model/pull/118 added support for removing duplicate values from the name field. This logic was not also applied to the `phrase` field.

Duplicate values do not affect whether or not a particular document will match for a given query, but they _do_ affect the scoring.

In some cases, the scoring boost for having tokens match twice from duplicates will over-rank a particular result. In other cases, the scoring penalty for having longer fields will under-rank a particular result.

To make sure our scoring is as fair as possible (pending other issues such as https://github.com/pelias/openstreetmap/issues/507), we should apply our current deduplication on both the `name` and `phrase` fields.