### PR TITLE
draft: create fewer intersection variations

### DIFF
--- a/post/intersections.js
+++ b/post/intersections.js
@@ -12,7 +12,7 @@ function intersections( doc ){
   // ensure both street & cross street props are set
   let street = doc.getAddress(ADDRESS_STREET_PROP);
   if( !_.isString(street) || _.isEmpty(street) ){ return; }
-  
+
   let cross_street = doc.getAddress(ADDRESS_CROSS_STREET_PROP);
   if( !_.isString(cross_street) || _.isEmpty(cross_street) ){ return; }
 
@@ -21,15 +21,15 @@ function intersections( doc ){
 
   // corner of A & B
   doc.setNameAlias('default', `${street} & ${cross_street}`);
-  doc.setNameAlias('default', `${street} @ ${cross_street}`);
+  //doc.setNameAlias('default', `${street} @ ${cross_street}`);
   doc.setNameAlias('default', `${street} at ${cross_street}`);
-  doc.setNameAlias('default', `Corner of ${street} & ${cross_street}`);
-  
+  //doc.setNameAlias('default', `Corner of ${street} & ${cross_street}`);
+
   // corner of B & A
   doc.setNameAlias('default', `${cross_street} & ${street}`);
-  doc.setNameAlias('default', `${cross_street} @ ${street}`);
+  //doc.setNameAlias('default', `${cross_street} @ ${street}`);
   doc.setNameAlias('default', `${cross_street} at ${street}`);
-  doc.setNameAlias('default', `Corner of ${cross_street} & ${street}`);
+  //doc.setNameAlias('default', `Corner of ${cross_street} & ${street}`);
 }
 
 module.exports = intersections;

--- a/test/post/intersections.js
+++ b/test/post/intersections.js
@@ -7,7 +7,7 @@ module.exports.tests = {};
 module.exports.tests.functional = function(test) {
   test('functional', function(t) {
     var doc = new Document('mysource','intersection','myid');
-    
+
     // street and cross_street not set
     intersections(doc);
     t.deepEqual(doc.getNameAliases('default'), [], 'no names set');
@@ -28,13 +28,9 @@ module.exports.tests.functional = function(test) {
     // intersection aliases defined
     t.deepEqual(doc.getNameAliases('default'), [
       'Example Street & Cross Street',
-      'Example Street @ Cross Street',
       'Example Street at Cross Street',
-      'Corner of Example Street & Cross Street',
       'Cross Street & Example Street',
-      'Cross Street @ Example Street',
       'Cross Street at Example Street',
-      'Corner of Cross Street & Example Street'
     ]);
 
     t.end();


### PR DESCRIPTION
Just like with venues, adding alt names can create scoring penalties(https://github.com/pelias/pelias/issues/862) or
boosts(https://github.com/pelias/openstreetmap/issues/507) that are undesirable.

Unfortunately we don't currently have a great way to handle all intersection searches without _some_ alt-names, but this change tests removing some of them to see if we can stabilize scoring a bit.