### PR TITLE
rename 'polygon' field to 'shape' to match pelias/schema

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -103,7 +103,7 @@ Document.prototype.toESDocument = function() {
     popularity: this.popularity,
     population: this.population,
     addendum: {},
-    polygon: this.shape
+    shape: this.shape
   };
 
   // add encoded addendum namespaces
@@ -136,8 +136,8 @@ Document.prototype.toESDocument = function() {
   if( !Object.keys( doc.addendum || {} ).length ){
     delete doc.addendum;
   }
-  if( !Object.keys( doc.polygon || {} ).length ){
-    delete doc.polygon;
+  if( !Object.keys( doc.shape || {} ).length ){
+    delete doc.shape;
   }
 
   return {
@@ -576,7 +576,7 @@ Document.prototype.getCentroid = function(){
 };
 
 // shape
-Document.prototype.setPolygon = function( value ){
+Document.prototype.setShape = function( value ){
 
  validate.type('object', value);
  validate.truthy(value);
@@ -585,7 +585,7 @@ Document.prototype.setPolygon = function( value ){
  return this;
 };
 
-Document.prototype.getPolygon = function(){
+Document.prototype.getShape = function(){
   return this.shape;
 };
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ var poi = new Document( 'geoname', 'venue', 1003 )
   .setAddendum('wikipedia', { slug: 'HackneyCityFarm' })
   .setAddendum('geonames', { foreignkey: 1 })
   .setCentroid({ lon: 0.5, lat: 50.1 })
-  .setPolygon( geojsonObject /* any valid geojson object */ )
+  .setShape( geojsonObject /* any valid geojson object */ )
   .setBoundingBox( bboxObject /* see tests for bbox syntax */ );
 
 console.log( poi );

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -24,7 +24,7 @@ for( var x=0; x<iterations; x++ ){
     .setPopulation(10)
     .setPopularity(3)
     .setCentroid({ lon: 0.5, lat: 50.1 })
-    .setPolygon(fixtures.new_zealand)
+    .setShape(fixtures.new_zealand)
     .setBoundingBox(fixtures.new_zealand_bbox)
     .toESDocument();
 }

--- a/test/document/shape.js
+++ b/test/document/shape.js
@@ -3,29 +3,29 @@ var Document = require('../../Document');
 
 module.exports.tests = {};
 
-module.exports.tests.getPolygon = function(test) {
-  test('getPolygon', function(t) {
+module.exports.tests.getShape = function(test) {
+  test('getShape', function(t) {
     var doc = new Document('mysource','mylayer','myid');
     doc.shape = { 'foo': 'bar' };
-    t.deepEqual(doc.getPolygon(), doc.shape, 'getter works');
+    t.deepEqual(doc.getShape(), doc.shape, 'getter works');
     t.end();
   });
 };
 
-module.exports.tests.setPolygon = function(test) {
-  test('setPolygon', function(t) {
+module.exports.tests.setShape = function(test) {
+  test('setShape', function(t) {
     var doc = new Document('mysource','mylayer','myid');
     t.equal(doc.shape, undefined, 'polygon undefined');
-    t.equal(doc.setPolygon({ 'foo': 'bar' }), doc, 'chainable');
+    t.equal(doc.setShape({ 'foo': 'bar' }), doc, 'chainable');
     t.deepEqual(doc.shape, { 'foo': 'bar' }, 'polygon set');
     t.end();
   });
-  test('setPolygon - validate', function(t) {
+  test('setShape - validate', function(t) {
     var doc = new Document('mysource','mylayer','myid');
-    t.throws( doc.setPolygon.bind(doc,undefined), null, 'invalid type' );
-    t.throws( doc.setPolygon.bind(doc,''), null, 'invalid type' );
-    t.throws( doc.setPolygon.bind(doc,1), null, 'invalid type' );
-    t.throws( doc.setPolygon.bind(doc,[]), null, 'invalid type' );
+    t.throws( doc.setShape.bind(doc,undefined), null, 'invalid type' );
+    t.throws( doc.setShape.bind(doc,''), null, 'invalid type' );
+    t.throws( doc.setShape.bind(doc,1), null, 'invalid type' );
+    t.throws( doc.setShape.bind(doc,[]), null, 'invalid type' );
     t.end();
   });
 };

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -40,7 +40,7 @@ module.exports.tests.toESDocument = function(test) {
     });
     doc.setPopulation(123);
     doc.setPopularity(456);
-    doc.setPolygon({ key: 'value' });
+    doc.setShape({ key: 'value' });
     doc.addCategory('category 1');
     doc.addCategory('category 2');
     doc.setAddendum('wikipedia', { slug: 'HackneyCityFarm' });
@@ -72,7 +72,7 @@ module.exports.tests.toESDocument = function(test) {
         bounding_box: '{"min_lat":12.121212,"max_lat":13.131313,"min_lon":21.212121,"max_lon":31.313131}',
         population: 123,
         popularity: 456,
-        polygon: {
+        shape: {
           key: 'value'
         },
         category: [
@@ -135,7 +135,7 @@ module.exports.tests.toESDocument = function(test) {
     t.false(esDoc.data.hasOwnProperty('center_point'), 'should not include center');
     t.false(esDoc.data.hasOwnProperty('population'), ' should not include population');
     t.false(esDoc.data.hasOwnProperty('popularity'), ' should not include popularity');
-    t.false(esDoc.data.hasOwnProperty('polygon'), ' should not include polygon');
+    t.false(esDoc.data.hasOwnProperty('shape'), ' should not include shape');
     t.end();
 
   });
@@ -192,7 +192,7 @@ module.exports.tests.toESDocument = function(test) {
     t.false(esDoc.data.hasOwnProperty('center_point'), 'should not include center');
     t.false(esDoc.data.hasOwnProperty('population'), ' should not include population');
     t.false(esDoc.data.hasOwnProperty('popularity'), ' should not include popularity');
-    t.false(esDoc.data.hasOwnProperty('polygon'), ' should not include polygon');
+    t.false(esDoc.data.hasOwnProperty('shape'), ' should not include shape');
     t.end();
 
   });

--- a/test/run.js
+++ b/test/run.js
@@ -14,7 +14,7 @@ var tests = [
   require('./document/addendum.js'),
   require('./document/address.js'),
   require('./document/parent.js'),
-  require('./document/polygon.js'),
+  require('./document/shape.js'),
   require('./document/category.js'),
   require('./document/boundingbox.js'),
   require('./document/source.js'),

--- a/test/serialize/test.js
+++ b/test/serialize/test.js
@@ -60,7 +60,7 @@ module.exports.tests.complete = function(test) {
       .setAddendum('wikipedia', { slug: 'HackneyCityFarm' })
       .setAddendum('geonames', { foreignkey: 1 })
       .setCentroid({ lon: 0.5, lat: 50.1 })
-      .setPolygon(fixtures.new_zealand)
+      .setShape(fixtures.new_zealand)
       .setBoundingBox(fixtures.new_zealand_bbox);
 
     var s = serializeDeserialize( doc );


### PR DESCRIPTION
The setPolygon() and getPolygon() methods are replaced by setShape() & getShape().

This ensures the field and method names are consistent with Pelias Schema.

As discussed in https://github.com/pelias/schema/pull/466 the field name should be `shape`, not `polygon`.

It's astounding that it's gone 3 years without anyone noticing that it didn't actually work, most likely because it's not very often used.