### PR TITLE
add alias for compound street names with abbreviated generic

### DIFF
--- a/post/_contractions_abbreviated.json
+++ b/post/_contractions_abbreviated.json
@@ -1,0 +1,23 @@
+{
+  "DEU": {
+    "platz": "pl",
+    "markt": "mkt",
+    "straße": "str",
+    "strasse": "str"
+  },
+  "CHE": {
+    "platz": "pl",
+    "markt": "mkt",
+    "straße": "str",
+    "strasse": "str"
+  },
+  "AUT": {
+    "platz": "pl",
+    "markt": "mkt",
+    "straße": "str",
+    "strasse": "str"
+  },
+  "NLD": {
+    "straat": "str"
+  }
+}

--- a/post/seperable_street_names.js
+++ b/post/seperable_street_names.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const TARGET_LAYERS = [ 'street', 'address', 'intersection' ];
 const expansions = require('./_expansions.json');
 const contractions = require('./_contractions.json');
+const contractions_abbreviated = require('./_contractions_abbreviated.json');
 
 function expand(str, mapping) {
   let tokens = str.split(' ');
@@ -38,61 +39,55 @@ function contract(str, mapping) {
 function expandAllFields(doc, mapping){
 
   // index expanded version of default name
-  const name = doc.getName('default');
-  if (_.isString(name) && !_.isEmpty(name)) {
+  _.castArray(_.get(doc.name, 'default', [])).forEach(name => {
     const expanded = expand(name, mapping);
     if (_.isString(expanded) && !_.isEmpty(expanded) && (name !== expanded)) {
       doc.setNameAlias('default', expanded);
     }
-  }
+  });
 
   // index expanded version of street name
-  const street = doc.getAddress('street');
-  if (_.isString(street) && !_.isEmpty(street)) {
+  _.castArray(_.get(doc.address_parts, 'street', [])).forEach(street => {
     const expanded = expand(street, mapping);
     if (_.isString(expanded) && !_.isEmpty(expanded) && (street !== expanded)) {
       doc.setAddressAlias('street', expanded);
     }
-  }
+  });
 
   // index expanded version of cross_street name
-  const cross_street = doc.getAddress('cross_street');
-  if (_.isString(cross_street) && !_.isEmpty(cross_street)) {
+  _.castArray(_.get(doc.address_parts, 'cross_street', [])).forEach(cross_street => {
     const expanded = expand(cross_street, mapping);
     if (_.isString(expanded) && !_.isEmpty(expanded) && (cross_street !== expanded)) {
       doc.setAddressAlias('cross_street', expanded);
     }
-  }
+  });
 }
 
 function contractAllFields(doc, mapping) {
 
   // index expanded version of default name
-  const name = doc.getName('default');
-  if (_.isString(name) && !_.isEmpty(name)) {
+  _.castArray(_.get(doc.name, 'default', [])).forEach(name => {
     const contracted = contract(name, mapping);
     if (_.isString(contracted) && !_.isEmpty(contracted) && (name !== contracted)) {
       doc.setNameAlias('default', contracted);
     }
-  }
+  });
 
   // index contracted version of street name
-  const street = doc.getAddress('street');
-  if (_.isString(street) && !_.isEmpty(street)) {
+  _.castArray(_.get(doc.address_parts, 'street', [])).forEach(street => {
     const contracted = contract(street, mapping);
     if (_.isString(contracted) && !_.isEmpty(contracted) && (street !== contracted)) {
       doc.setAddressAlias('street', contracted);
     }
-  }
+  });
 
   // index contracted version of cross_street name
-  const cross_street = doc.getAddress('cross_street');
-  if (_.isString(cross_street) && !_.isEmpty(cross_street)) {
+  _.castArray(_.get(doc.address_parts, 'cross_street', [])).forEach(cross_street => {
     const contracted = contract(cross_street, mapping);
     if (_.isString(contracted) && !_.isEmpty(contracted) && (cross_street !== contracted)) {
       doc.setAddressAlias('cross_street', contracted);
     }
-  }
+  });
 }
 
 function post(doc) {
@@ -101,19 +96,26 @@ function post(doc) {
   if( !TARGET_LAYERS.includes( doc.getLayer() ) ) { return; }
 
   // detect document country code
-  let docCountryCode = _.get(doc, 'parent.country_a[0]');
+  let docCountryCode = _.get(doc, 'parent.country_a[0]') || _.get(doc, 'parent.dependency_a[0]');
   if( !_.isString(docCountryCode) || docCountryCode.length !== 3 ) { return; }
+  docCountryCode = docCountryCode.toUpperCase();
 
   // expansions
-  let mapping_expansions = expansions[docCountryCode.toUpperCase()];
+  const mapping_expansions = expansions[docCountryCode];
   if( _.isObject( mapping_expansions ) ) {
     expandAllFields(doc, mapping_expansions);
   }
 
   // contractions
-  let mapping_contractions = contractions[docCountryCode.toUpperCase()];
+  const mapping_contractions = contractions[docCountryCode];
   if( _.isObject( mapping_contractions ) ) {
     contractAllFields(doc, mapping_contractions);
+  }
+
+  // abbreviated contractions
+  const mapping_contractions_abbr = contractions_abbreviated[docCountryCode];
+  if (_.isObject(mapping_contractions_abbr)) {
+    contractAllFields(doc, mapping_contractions_abbr);
   }
 }
 


### PR DESCRIPTION
implementation of https://github.com/pelias/model/issues/144

this method is slightly different from previous in that *all* versions of the name (including aliases) are considered rather than only the primary name.

note: this method produces duplicate names, the subsequent post processing step 'deduplication' handles removing duplicate entries so I felt it wasn't necessary to do so within this script, at the cost of having duplicate entries in the tests.

resolves https://github.com/pelias/model/issues/144
resolves https://github.com/pelias/api/issues/1594