### PR TITLE
Adding parentFields validation in addParent.

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -313,6 +313,8 @@ Document.prototype.delName = function( prop ){
 // parent
 Document.prototype.addParent = function( field, name, id, abbr, source ){
 
+  validate.property(parentFields, field);
+
   var add = function( prop, value ){
 
     // create new parent array if required
@@ -377,7 +379,7 @@ Document.prototype.addParent = function( field, name, id, abbr, source ){
   return this;
 };
 
-// clear all all added values
+// clear all added values
 Document.prototype.clearParent = function(field) {
 
   // field has never been set
@@ -436,7 +438,7 @@ Document.prototype.setAddressAlias = function( prop, value ){
     this.address_parts[ prop ] = [ stringValue ];
   }
 
-  // is the array empty? ie. no prior call to setAddress()
+  // is the array empty? i.e. no prior call to setAddress()
   // in this case we will also set element 0 (the element used for display)
   if( !this.address_parts[ prop ].length ){
     this.setAddress( prop, value );

--- a/Document.js
+++ b/Document.js
@@ -17,7 +17,6 @@ const parentFields = [
   'borough',
   'locality',
   'localadmin',
-  'macrohood',
   'neighbourhood',
   'postalcode',
   'ocean',

--- a/test/Document.js
+++ b/test/Document.js
@@ -140,6 +140,20 @@ module.exports.tests.parent_types = (test) => {
 
   });
 
+  test('Invalid parent field name', (t) => {
+    const doc = new Document('mysource', 'mylayer', 'myid');
+
+    t.throws(
+      () => doc.addParent('someRandomName', 'name 1', 'id 1', 'abbr 1'),
+      'invalid property: someRandomName, should be one of: ' +
+      'continent,country,dependency,macroregion,region,macrocounty,county,borough,' +
+      'locality,localadmin,macrohood,neighbourhood,postalcode,ocean,marinearea,empire',
+      'Should fail for invalid parent field.');
+
+    t.end();
+
+  });
+
   test('non-WOF placetype arguments should return false', (t) => {
     const doc = new Document('mysource', 'mylayer', 'myid');
 

--- a/test/Document.js
+++ b/test/Document.js
@@ -104,7 +104,6 @@ module.exports.tests.parent_types = (test) => {
       'borough',
       'locality',
       'localadmin',
-      'macrohood',
       'neighbourhood',
       'postalcode',
       'ocean',
@@ -147,7 +146,7 @@ module.exports.tests.parent_types = (test) => {
       () => doc.addParent('someRandomName', 'name 1', 'id 1', 'abbr 1'),
       'invalid property: someRandomName, should be one of: ' +
       'continent,country,dependency,macroregion,region,macrocounty,county,borough,' +
-      'locality,localadmin,macrohood,neighbourhood,postalcode,ocean,marinearea,empire',
+      'locality,localadmin,neighbourhood,postalcode,ocean,marinearea,empire',
       'Should fail for invalid parent field.');
 
     t.end();


### PR DESCRIPTION
:wave: 

---
#### Here's the reason for this change :rocket:
I need to update the [pelias-csv-importer](https://github.com/pelias/csv-importer) to support the import of parent field. And found that the addParent function does not validate the field name with the list of parentFields, like it is done with the addressFields in setAddress function.

---
#### Here's what actually got changed :clap:
Updated the addParent to function by adding the property validation for parentFields.
Added the unit test to test the change.
