### PR TITLE
remove _type

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -143,10 +143,6 @@ Document.prototype.toESDocument = function() {
   return {
     _index: _.get(config, 'schema.indexName', 'pelias'),
     _id: this.getGid(),
-    // In ES7, the only allowed document type will be `_doc`.
-    // However underscores are not allowed until ES6, so use `doc` for now
-    // see https://github.com/elastic/elasticsearch/pull/27816
-    _type: _.get(config, 'schema.typeName', 'doc'),
     data: doc
   };
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "lodash": "^4.6.1",
-    "pelias-config": "^4.5.0",
+    "pelias-config": "^6.0.0",
     "through2": "^3.0.0"
   },
   "devDependencies": {

--- a/test/document/toESDocument.js
+++ b/test/document/toESDocument.js
@@ -3,8 +3,7 @@ const codec = require('../../codec');
 
 var fakeGeneratedConfig = {
   schema: {
-    indexName: 'example_index',
-    typeName: 'example_type'
+    indexName: 'example_index'
   }
 };
 
@@ -50,7 +49,6 @@ module.exports.tests.toESDocument = function(test) {
 
     var expected = {
       _index: 'example_index',
-      _type: 'example_type',
       _id: 'mysource:mylayer:myid',
       data: {
         layer: 'mylayer',
@@ -102,7 +100,6 @@ module.exports.tests.toESDocument = function(test) {
 
     var expected = {
       _index: 'example_index',
-      _type: 'example_type',
       _id: 'mysource:mylayer:myid',
       data: {
         source: 'mysource',
@@ -156,7 +153,6 @@ module.exports.tests.toESDocument = function(test) {
 
     var expected = {
       _index: 'example_index',
-      _type: 'example_type',
       _id: 'mysource:mylayer:myid',
       data: {
         source: 'mysource',


### PR DESCRIPTION
now that elasticsearch v6 support has been dropped we can remove any references to `_type` from this repo.

related: https://github.com/pelias/dbclient/pull/128

note: this should be versioned as a BREAKING CHANGE