### PR TITLE
Disable language field trimming

### DIFF
--- a/Document.js
+++ b/Document.js
@@ -43,7 +43,7 @@ function Document( source, layer, source_id ){
   this.addPostProcessingScript( require('./post/seperable_street_names').post );
   this.addPostProcessingScript( require('./post/alphanumeric_postcodes') );
   this.addPostProcessingScript( require('./post/deduplication') );
-  this.addPostProcessingScript( require('./post/language_field_trimming') );
+  // this.addPostProcessingScript( require('./post/language_field_trimming') );
   this.addPostProcessingScript( require('./post/popularity') );
 
   // mandatory properties


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
When providing the `lang` parameters on the autocomplete endpoint, the translation will not work if the `name[lang]` entry got trimmed.

Example for "Ho Chi Minh" we have 

```json
{
   "name": {
     "default": [
        "Thành Phố Hồ Chí Minh",
        "Ho Chi Minh City"
      ],
     "af": "Ho Chi Minh-stad",
     "am": "ሆ ቺ ሚን ከተማ",
    ....
    // no "en", since the value of "en" matches the second default value
}
```

The result will be "Thành Phố Hồ Chí Minh" instead of "Ho Chi Minh City" when providing `lang=en`, since no `name.en` exists anymore after trimming.

---
#### Here's what actually got changed :clap:

For now I just commented out the trimming for demo purpose


