### PR TITLE
zero prefixed house numbers

### DIFF
--- a/post/zero_prefixed_house_numbers.js
+++ b/post/zero_prefixed_house_numbers.js
@@ -22,7 +22,39 @@ function housenumber(doc) {
   if ( houseno.length < 2 || !houseno.startsWith('0') ) { return; }
 
   // trim leading zeros
-  doc.setAddress('number', houseno.replace(/^0+/, ''));
+  const replacement = houseno.replace(/^0+/, '') || '0';
+
+  // update housenumber
+  doc.setAddress('number', replacement);
+
+  //  update address 'name' fields
+  names(doc, houseno, replacement);
+}
+
+function names(doc, houseno, replacement) {
+  // only records on the address layer have the housenumber in the name.
+  if( doc.getLayer() !== 'address' ){ return; }
+
+  // ensure street is set
+  let street = doc.getAddress('street');
+  if( !_.isString(street) || _.isEmpty(street) ){ return; }
+
+  // load name data. ie: an object keyed by language codes, each value is an array of names
+  if (!_.isPlainObject(doc.name)) { return; }
+
+  // $houseno must be surrounded by whitespace or start/end of text
+  const regexp = new RegExp('\\b' + _.escapeRegExp(houseno) + '\\b');
+
+  // iterate over all languages
+  _.each(doc.name, (names, lang) => {
+    if (_.isEmpty(names)) { return; }
+
+    // replace house number in name fields
+    const replaced = _.castArray(names).map(name => name.replace(regexp, replacement));
+
+    // update lang
+    doc.name[lang] = _.size(replaced) === 1 ? _.first(replaced) : replaced;
+  });
 }
 
 module.exports = housenumber;

--- a/test/post/zero_prefixed_house_numbers.js
+++ b/test/post/zero_prefixed_house_numbers.js
@@ -5,7 +5,7 @@ module.exports.tests = {};
 
 module.exports.tests.noop = function(test) {
   test('noop: house number not set', function(t) {
-    const doc = new Document('mysource', 'mylayer', 'myid');
+    const doc = new Document('mysource', 'address', 'myid');
 
     housenumber(doc);
 
@@ -16,7 +16,7 @@ module.exports.tests.noop = function(test) {
   });
 
   test('noop: house no leading zero', function(t) {
-    const doc = new Document('mysource', 'mylayer', 'myid');
+    const doc = new Document('mysource', 'address', 'myid');
     doc.setAddress('number', '10');
 
     housenumber(doc);
@@ -28,7 +28,7 @@ module.exports.tests.noop = function(test) {
   });
 
   test('noop: house no is literally zero', function(t) {
-    const doc = new Document('mysource', 'mylayer', 'myid');
+    const doc = new Document('mysource', 'address', 'myid');
     doc.setAddress('number', '0');
 
     housenumber(doc);
@@ -73,6 +73,154 @@ module.exports.tests.strip_prefix = function(test) {
 
     // prefix removed
     t.equal(doc.getAddress('number'), '9990', 'prefix removed');
+
+    t.end();
+  });
+
+  test('strip: house number with multiple zeros', function(t) {
+    const doc = new Document('mysource', 'mylayer', 'myid');
+    doc.setAddress('number', '00000');
+
+    housenumber(doc);
+
+    // prefix removed
+    t.equal(doc.getAddress('number'), '0', 'prefix removed');
+
+    t.end();
+  });
+};
+
+module.exports.tests.update_names = function(test) {
+  test('name: scalar', function(t) {
+    const doc = new Document('mysource', 'address', 'myid');
+    doc.setAddress('number', '010');
+    doc.setAddress('street', 'Main Street');
+    doc.setName('default', '010 Main Street');
+
+    housenumber(doc);
+
+    // prefix removed
+    t.equal(doc.getAddress('number'), '10', 'prefix removed');
+    t.equal(doc.getAddress('street'), 'Main Street', 'no-op');
+    t.equal(doc.getName('default'), '10 Main Street', 'prefix removed');
+
+    t.end();
+  });
+
+  test('name: array', function(t) {
+    const doc = new Document('mysource', 'address', 'myid');
+    doc.setAddress('number', '010');
+    doc.setAddress('street', 'Main Street');
+    doc.setName('default', '010 Main Street');
+    doc.setNameAlias('default', '010 Main Street');
+
+    housenumber(doc);
+
+    // prefix removed
+    t.equal(doc.getAddress('number'), '10', 'prefix removed');
+    t.equal(doc.getAddress('street'), 'Main Street', 'no-op');
+    t.equal(doc.getName('default'), '10 Main Street', 'prefix removed');
+    t.deepEqual(doc.getNameAliases('default'), ['10 Main Street'], 'prefix removed');
+
+    t.end();
+  });
+
+  test('name: scalar - invert', function(t) {
+    const doc = new Document('mysource', 'address', 'myid');
+    doc.setAddress('number', '010');
+    doc.setAddress('street', 'Hauptstraße');
+    doc.setName('default', 'Hauptstraße 010');
+
+    housenumber(doc);
+
+    // prefix removed
+    t.equal(doc.getAddress('number'), '10', 'prefix removed');
+    t.equal(doc.getAddress('street'), 'Hauptstraße', 'no-op');
+    t.equal(doc.getName('default'), 'Hauptstraße 10', 'prefix removed');
+
+    t.end();
+  });
+
+  test('name: array - invert', function(t) {
+    const doc = new Document('mysource', 'address', 'myid');
+    doc.setAddress('number', '010');
+    doc.setAddress('street', 'Hauptstraße');
+    doc.setName('default', 'Hauptstraße 010');
+    doc.setNameAlias('default', 'Hauptstraße 010');
+
+    housenumber(doc);
+
+    // prefix removed
+    t.equal(doc.getAddress('number'), '10', 'prefix removed');
+    t.equal(doc.getAddress('street'), 'Hauptstraße', 'no-op');
+    t.equal(doc.getName('default'), 'Hauptstraße 10', 'prefix removed');
+    t.deepEqual(doc.getNameAliases('default'), ['Hauptstraße 10'], 'prefix removed');
+
+    t.end();
+  });
+
+  test('name: scalar - infix ignored', function(t) {
+    const doc = new Document('mysource', 'address', 'myid');
+    doc.setAddress('number', '010');
+    doc.setAddress('street', '0100 Street');
+    doc.setName('default', '010 0100 Street');
+
+    housenumber(doc);
+
+    // prefix removed
+    t.equal(doc.getAddress('number'), '10', 'prefix removed');
+    t.equal(doc.getAddress('street'), '0100 Street', 'no-op');
+    t.equal(doc.getName('default'), '10 0100 Street', 'prefix removed');
+
+    t.end();
+  });
+
+  test('name: scalar - unit maintained', function(t) {
+    const doc = new Document('mysource', 'address', 'myid');
+    doc.setAddress('number', '010');
+    doc.setAddress('unit', '1A');
+    doc.setAddress('street', 'Main Street');
+    doc.setName('default', '1A 010 Main Street');
+
+    housenumber(doc);
+
+    // prefix removed
+    t.equal(doc.getAddress('number'), '10', 'prefix removed');
+    t.equal(doc.getAddress('unit'), '1A', 'no-op');
+    t.equal(doc.getAddress('street'), 'Main Street', 'no-op');
+    t.equal(doc.getName('default'), '1A 10 Main Street', 'prefix removed');
+
+    t.end();
+  });
+
+  test('name: scalar - ordinal ignored', function(t) {
+    const doc = new Document('mysource', 'address', 'myid');
+    doc.setAddress('number', '010');
+    doc.setAddress('street', '010th Street');
+    doc.setName('default', '010 010th Street');
+
+    housenumber(doc);
+
+    // prefix removed
+    t.equal(doc.getAddress('number'), '10', 'prefix removed');
+    t.equal(doc.getAddress('street'), '010th Street', 'no-op');
+    t.equal(doc.getName('default'), '10 010th Street', 'prefix removed');
+
+    t.end();
+  });
+
+  test('name: scalar - only first match replaced', function(t) {
+    const doc = new Document('mysource', 'address', 'myid');
+    doc.setAddress('number', '010');
+    doc.setAddress('street', '010 Street');
+    doc.setName('default', '010 010 Street');
+
+    housenumber(doc);
+
+    // prefix removed
+    t.equal(doc.getAddress('number'), '10', 'prefix removed');
+    t.equal(doc.getAddress('street'), '010 Street', 'no-op');
+    t.equal(doc.getName('default'), '10 010 Street', 'prefix removed');
 
     t.end();
   });


### PR DESCRIPTION
following on from https://github.com/pelias/model/pull/162 this PR addresses some issues and omissions I discovered when updating the importers:

1. A house number of many zero (such as `00000`) would return an empty string and error, this actually occurs in live data, we now squash it to `0`.

2. The 'name' field(s) were not being updated. I thought through a few different options including updating all the importers directly and settled on this code which handles it fairly elegantly.